### PR TITLE
Add the ability to switch off the creation of symlink

### DIFF
--- a/common/torque2/client/config.tpl
+++ b/common/torque2/client/config.tpl
@@ -301,34 +301,35 @@ include { 'components/altlogrotate/config' };
 include { 'components/symlink/config' };
 
 "/software/components/symlink/links" = { 
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qstat",
-                               "target", "/usr/bin/qstat-torque",
-                               "replace", nlist("all","yes"),                                                                                                                                                                                                                                                                                                                                                                            
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qsub",
-                               "target", "/usr/bin/qsub-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qhold",
-                               "target", "/usr/bin/qhold-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qrls",
-                               "target", "/usr/bin/qrls-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qalter",
-                               "target", "/usr/bin/qalter-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qselect",
-                               "target", "/usr/bin/qselect-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qdel",
-                               "target", "/usr/bin/qdel-torque",
-                               "replace", nlist("all","yes"),
-                              );  
+  if (TORQUE_PROVIDER=='lal') {
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qstat",
+                                 "target", "/usr/bin/qstat-torque",
+                                 "replace", nlist("all","yes"),                                                 );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qsub",
+                                 "target", "/usr/bin/qsub-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qhold",
+                                 "target", "/usr/bin/qhold-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qrls",
+                                 "target", "/usr/bin/qrls-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qalter",
+                                 "target", "/usr/bin/qalter-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qselect",
+                                 "target", "/usr/bin/qselect-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qdel",
+                                 "target", "/usr/bin/qdel-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+  };
   SELF;
 };
 

--- a/common/torque2/config.tpl
+++ b/common/torque2/config.tpl
@@ -16,6 +16,9 @@ variable TORQUE_SERVER_PRIV_HOST ?= if ( exists(CE_PRIV_HOST) ) {
 # Directory where configuration/working directories are located
 variable TORQUE_CONFIG_DIR ?= '/var/torque';
 
+# Define the Torque RPM provider
+variable TORQUE_PROVIDER ?= 'lal';
+
 # ----------------------------------------------------------------------------
 # etcservices
 # ----------------------------------------------------------------------------

--- a/common/torque2/server/config.tpl
+++ b/common/torque2/server/config.tpl
@@ -628,34 +628,36 @@ variable PBS_MONITORING_SCRIPT ?= undef;
 include { 'components/symlink/config' };
 
 "/software/components/symlink/links" = { 
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qstat",
-                               "target", "/usr/bin/qstat-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qsub",
-                               "target", "/usr/bin/qsub-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qhold",
-                               "target", "/usr/bin/qhold-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qrls",
-                               "target", "/usr/bin/qrls-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qalter",
-                               "target", "/usr/bin/qalter-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qselect",
-                               "target", "/usr/bin/qselect-torque",
-                               "replace", nlist("all","yes"),
-                              );  
-  SELF[length(SELF)] =   nlist("name", "/usr/bin/qdel",
-                               "target", "/usr/bin/qdel-torque",
-                               "replace", nlist("all","yes"),
-                              );  
+  if (TORQUE_PROVIDER=='lal') {
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qstat",
+                                 "target", "/usr/bin/qstat-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qsub",
+                                 "target", "/usr/bin/qsub-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qhold",
+                                 "target", "/usr/bin/qhold-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qrls",
+                                 "target", "/usr/bin/qrls-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qalter",
+                                 "target", "/usr/bin/qalter-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qselect",
+                                 "target", "/usr/bin/qselect-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+    SELF[length(SELF)] =   nlist("name", "/usr/bin/qdel",
+                                 "target", "/usr/bin/qdel-torque",
+                                 "replace", nlist("all","yes"),
+                                );
+  };
   SELF;
 };
 


### PR DESCRIPTION
When using the Torque RPMs provided by the LAL, it is needed to create symbolic links linked to  'torque-qstat', 'torque-qdel', ..., binaries. If a site want to use another RPM that provide directly the binaries with the right name, the symbolic links should not be created.
