### PR TITLE
Various CREAM CE and WN configuration fixes

### DIFF
--- a/feature/gip/ce.pan
+++ b/feature/gip/ce.pan
@@ -35,18 +35,15 @@ variable CREAM_CE_VERSION ?= '1.14.0';
 
 
 variable CE_HOSTS_CREAM ?= list();
-variable CE_HOSTS_LCG ?= list();
 
 variable CE_FLAVOR ?= if ( is_defined(CE_HOSTS_CREAM) && (index(FULL_HOSTNAME,CE_HOSTS_CREAM) >= 0) ) {
                         'cream';
-                      } else if ( is_defined(CE_HOSTS_LCG) && (index(FULL_HOSTNAME,CE_HOSTS_LCG) >= 0) ) {
-                        'lcg';
                       } else {
                         undef;
                       };
 variable CE_FLAVOR = {
-  if ( is_defined(CE_FLAVOR) && !match(CE_FLAVOR,'cream|lcg') ) {
-    error("Invalid value for CE_FLAVOR ("+CE_FLAVOR+"). Must be 'lcg' or 'cream'.");
+  if ( is_defined(CE_FLAVOR) && !match(CE_FLAVOR,'cream') ) {
+    error("Invalid value for CE_FLAVOR ("+CE_FLAVOR+"). Must be 'cream'.");
   };
   SELF;
 };
@@ -103,7 +100,6 @@ variable CE_CLOSE_SE_LIST ?= undef;
 # CE port for each CE flavor
 variable CE_PORT = nlist(
   'cream', 8443,
-  'lcg', 2119,
 );
 
 # For GlueHostArchitecturePlatformType, assume the same type as CE until we support several subclusters
@@ -113,7 +109,6 @@ variable CE_WN_ARCH ?= PKG_ARCH_DEFAULT;
 # CE implementation for each flavor
 variable GLUE_CE_IMPLEMENTATION = nlist(
   'cream',    'CREAM',
-  'lcg',      'LCG-CE',
 );
 
 # Which version of tomcat
@@ -126,7 +121,6 @@ variable TOMCAT_SERVICE ?= 'tomcat6';
 variable GIP_PROVIDER_SERVICE_CONF_BASE ?= GIP_SCRIPTS_CONF_DIR + '/glite-info-service';
 variable GIP_CE_SERVICES = nlist(
   'cream',    list('creamce','cemon'),
-  'lcg',      list('gatekeeper'),
 );
 variable GIP_PROVIDER_SUBSERVICE ?= nlist(
   'creamce',    GIP_SCRIPTS_DIR + '/glite-info-service-cream',
@@ -502,7 +496,7 @@ include { if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) 'feature/gip/mpi' }
         if ( index(ce,CE_HOSTS_CREAM) >= 0 ) {
           ce_flavor = 'cream';
         } else {
-          ce_flavor = 'lcg';
+          error(format('Non CREAM CE found (%s): only CREAM CE are supported',ce));
         };
         
         if ( ce_flavor == 'cream' ) {

--- a/personality/cream_ce/cleanup-accounts.pan
+++ b/personality/cream_ce/cleanup-accounts.pan
@@ -1,0 +1,81 @@
+# Configure cron job to clean up home directories
+
+template personality/cream_ce/cleanup-accounts;
+
+
+# Age in days for files in home directories to be cleaned up
+variable CE_CLEANUP_ACCOUNTS_IDLE ?= 15;
+variable CE_CLEANUP_ACCOUNTS_DAYS ?= "Sun,Wed";    # In cron format
+variable CE_CLEANUP_ACCOUNTS_LOCAL_ONLY ?= false;
+variable CE_CLEANUP_ACCOUNTS_USE_GRIDMAPDIR ?= true;
+variable CE_CLEANUP_ACCOUNTS_SITE_OPTIONS ?= '';        # Use to specify other options
+
+# Set options according to previous variables
+variable CE_CLEANUP_ACCOUNTS_BASE_OPTIONS = {
+  options = '';
+  if ( ! CE_CLEANUP_ACCOUNTS_LOCAL_ONLY ) {
+    options = options + ' -F';
+  };
+  if ( CE_CLEANUP_ACCOUNTS_USE_GRIDMAPDIR ) {
+    options = options + ' -d ' + SITE_DEF_GRIDMAPDIR;
+  };
+  options;
+};
+
+# Install cron to do pool accounts cleanup.
+# This is done using option -F to force cleanup on non local directories
+# as this cron job is not installed on other machine types (WNs, NFS servers...)
+# because the script requires a gridmapdir to be present.
+# In addition to pool accounts present in gridmapdir (all already used pool accounts), add
+# explicitly accounts used to map specific groups and roles, except those for which home directory
+# matches VO software area.
+
+include { 'components/cron/config' };
+include { 'components/altlogrotate/config' };
+include { 'components/filecopy/config' };
+
+variable CE_CLEANUP_ACCOUNTS_CONFIG_FILE = '/etc/cleanup-grid-accounts.conf';
+variable CE_CLEANUP_ACCOUNTS_CONFIG = {
+  non_pool_accounts = '';
+  foreach (vo;vo_params;VO_INFO) {
+    foreach (user;params;vo_params['accounts']['users']) {
+      if ( (!exists(params['poolSize']) || !is_defined(params['poolSize']) || (params['poolSize'] == 0)) &&
+           (!exists(vo_params['swarea']['paths']) || (length(vo_params['swarea']['paths']) == 0) ||
+                                       !match(vo_params['swarea']['paths'][0]['path'],'^'+params['homeDir'])) ) {
+        non_pool_accounts = non_pool_accounts + user + ' ';
+      };
+    };
+  };
+  "EXTRA='"+to_string(non_pool_accounts)+"'\n";
+};
+
+"/software/components/filecopy/services" = {
+  SELF[escape(CE_CLEANUP_ACCOUNTS_CONFIG_FILE)] = nlist('config', CE_CLEANUP_ACCOUNTS_CONFIG,
+                                                        'perms', '0755',
+                                                        'owner', 'root:root',
+                                                       );
+  SELF;
+};
+
+"/software/components/cron/entries" =
+  push(nlist(
+    "name","cleanup-grid-accounts",
+    "user","root",
+    "frequency", "0 23 * * "+CE_CLEANUP_ACCOUNTS_DAYS,
+    "command", "PATH=/sbin:/bin:/usr/sbin:/usr/bin; "+
+               "/usr/sbin/cleanup-grid-accounts.sh -v -c "+CE_CLEANUP_ACCOUNTS_CONFIG_FILE+' '+
+               CE_CLEANUP_ACCOUNTS_BASE_OPTIONS+' '+CE_CLEANUP_ACCOUNTS_SITE_OPTIONS+
+               ' -i '+to_string(CE_CLEANUP_ACCOUNTS_IDLE)
+      ));
+
+
+# Configure altrotate for LCG CE related log files
+
+"/software/components/altlogrotate/entries/cleanup-grid-accounts" =
+  nlist("pattern", "/var/log/cleanup-grid-accounts.ncm-cron.log",
+        "compress", true,
+        "missingok", true,
+        "frequency", "monthly",
+        "create", true,
+        "ifempty", true,
+        "rotate", 1);

--- a/personality/cream_ce/config.pan
+++ b/personality/cream_ce/config.pan
@@ -24,11 +24,16 @@ variable GLOBUS_GRIDFTP_CFGFILE ?= "/usr/etc/gridftp.conf";
                                "target", "/var/lib/trustmanager-tomcat",
                                "replace", nlist("all","yes"),
                               );
+  SELF[length(SELF)] =   nlist("name", "/usr/share/tomcat6/lib/canl.jar",
+                               "target", "/usr/share/java/canl.jar",
+                               "replace", nlist("all","yes"),
+                              );
   SELF;
 };
 
 
-#TO_BE_FIXED: there are problems in the conf of the bdii which I cannot fix.. this just avoids that the component causes damages
+# Required by ncm-lcgbdii after change of GLITE_LOCATION in EMI
+# FIXME: to be reviewed
 "/software/components/lcgbdii/dir" = "/opt/glite";
 
 ############################################################################
@@ -174,18 +179,19 @@ include { 'components/mysql/config' };
 include { 'personality/cream_ce/upgrade_db' };
 
 
-# If home directories are not shared with a LCG CE, install LCG CE cron
-# job to do account home directory cleanup (see https://savannah.cern.ch/bugs/?73283)
-variable CREAM_HOMEDIR_CLEANUP ?= if ( is_defined(CE_HOSTS_LCG) &&
-                                       (length(CE_HOSTS_LCG) > 0 ) &&
-                                       CE_SHARED_HOMES ) {
-                                    false;
-                                  } else {
+@{
+desc =  if true, configure a cron job to do the home directory cleanup of grid pool accounts
+values = true or false
+default = true if home directories are shared with WNs, else false
+required = no
+}
+variable CREAM_HOMEDIR_CLEANUP ?= if ( CE_SHARED_HOMES ) {
                                     true;
+                                  } else {
+                                    false;
  
                                  };
-#TO_BE_FIXED: just commented. To be checked later
-#include { if ( CREAM_HOMEDIR_CLEANUP ) 'lcg/ce/cleanup-accounts' };
+include { if ( CREAM_HOMEDIR_CLEANUP ) 'personality/cream_ce/cleanup-accounts' };
 
 
 #------------------------------------------------------------------------------

--- a/personality/wn/config.pan
+++ b/personality/wn/config.pan
@@ -5,4 +5,4 @@ unique template personality/wn/config;
 # When not using home directories, configure cleanup of home directories
 variable CE_CLEANUP_ACCOUNTS_LOCAL_ONLY ?= true;
 variable CE_CLEANUP_ACCOUNTS_USE_GRIDMAPDIR ?= false;
-include { if ( ! CE_SHARED_HOMES ) 'lcg/ce/cleanup-accounts' };
+include { if ( ! CE_SHARED_HOMES ) 'personality/cream_ce/cleanup-accounts' };


### PR DESCRIPTION
- Missing jar symlink (canl.jar)
- Restore disabled configuration of cleanup-grid-accounts
- Suppress support for very obsolete LCG CE
