### PR TITLE
VOMS config: do not restart Tomcat after a config change by default

### DIFF
--- a/personality/voms/variables.pan
+++ b/personality/voms/variables.pan
@@ -16,3 +16,4 @@ variable VOMS_TOMCAT_MX ?= '750M';
 variable VOMS_TOMCAT_MAXPERMSIZE ?= '1125m';
 variable VOMS_TOMCAT_MANAGE_LIMITS_FILE ?= true;
 
+variable VOMS_TOMCAT_RESTART_CONFIG ?= false;

--- a/personality/voms/vos.pan
+++ b/personality/voms/vos.pan
@@ -51,7 +51,7 @@ include { 'components/filecopy/config' };
     'config', CONTENTS,
     'owner', 'root:root',
     'perms', '0755',
-    'restart', '/var/run/quattor/create-voms.sh',
+    'restart', if (VOMS_TOMCAT_RESTART_CONFIG) { '/var/run/quattor/create-voms.sh'; } else { null; }    
 );
 
 #/usr/sbin/voms-admin-configure install --dbtype mysql \ 


### PR DESCRIPTION
variable VOMS_TOMCAT_RESTART_CONFIG added to force it
