### PR TITLE
Fix X509_USER_PROXY issue with last version of glite-wms-ui-commands

### DIFF
--- a/personality/ui/config.pan
+++ b/personality/ui/config.pan
@@ -1,0 +1,9 @@
+unique template personality/ui/config;
+
+variable X509_USER_PROXY_PATH ?= "/tmp/x509up_u$(id -u)";
+
+#-----------------------------------------------------------------------------
+# Define need variable for glite-wms-command
+#-----------------------------------------------------------------------------
+'/software/components/profile' = component_profile_add_env(GLITE_GRID_ENV_PROFILE, nlist('X509_USER_PROXY',X509_USER_PROXY_PATH));
+

--- a/personality/ui/service.pan
+++ b/personality/ui/service.pan
@@ -52,3 +52,7 @@ include { 'features/gsissh/client/config' };
 
 # Configure MPI.
 include { 'features/mpi/config' };
+
+# UI specific tasks
+include { 'personality/ui/config' };
+


### PR DESCRIPTION
Fix X509_USER_PROXY issue with glite-wms-ui-commands-3.5.2-1.sl6.x86_64. The variable X509_USER_PROXY_PATH can be also configured to any other value.
