### PR TITLE
Permit to define glexec exec permission depending on the GLEXEC_OPMODE

### DIFF
--- a/features/glexec/base.pan
+++ b/features/glexec/base.pan
@@ -39,10 +39,5 @@ include { 'users/glexec' };
                              'perm', '0755',
                              'type', 'd',
                             );
-  SELF[length(SELF)] = nlist('path', GLITE_LOCATION+'/sbin/glexec',
-                             'owner', 'root:'+GLEXEC_GROUP,
-                             'perm', '6555',
-                             'type', 'f',
-                            );
   SELF;
 };

--- a/features/glexec/cream_ce/config.pan
+++ b/features/glexec/cream_ce/config.pan
@@ -18,6 +18,20 @@ include { 'features/lcas/glexec' };
 
 
 #-----------------------------------------------------------------------------
+# /usr/sbin/glexec mode -> yaim/functions/config_cream_glexec
+#-----------------------------------------------------------------------------
+'/software/components/dirperm/paths' = {
+  SELF[length(SELF)] = nlist('path', GLITE_LOCATION+'/sbin/glexec',
+                             'owner', 'root:'+GLEXEC_GROUP,
+                             'perm', '6555',
+                             'type', 'f',
+                            );
+
+  SELF;
+};
+
+
+#-----------------------------------------------------------------------------
 # glexec configuration file
 #-----------------------------------------------------------------------------
 variable GLEXEC_CONF_FILE = EMI_LOCATION + '/etc/glexec.conf';

--- a/features/glexec/wn/config.pan
+++ b/features/glexec/wn/config.pan
@@ -188,3 +188,21 @@ variable GLEXEC_FILE_PERMS = {
              'type', 'f',
             )
       );
+
+'/software/components/dirperm/paths' = {
+  if (GLEXEC_OPMODE=="setuid") {
+    SELF[length(SELF)] = nlist('path', GLITE_LOCATION+'/sbin/glexec',
+                               'owner', 'root:'+GLEXEC_GROUP,
+                               'perm', '6111',
+                               'type', 'f',
+                              );
+  } else {
+    SELF[length(SELF)] = nlist('path', GLITE_LOCATION+'/sbin/glexec',
+                               'owner', 'root:'+GLEXEC_GROUP,
+                               'perm', '0555',
+                               'type', 'f',
+                             );
+  };
+
+  SELF;
+};


### PR DESCRIPTION
On WN, /usr/sbin/glexec mode depends upon GLEXEC_OPMODE. This fix permit to define it with Quattor.
