### PR TITLE
LB locallogger: remove useless configuration of glitestartup configuration module

### DIFF
--- a/features/lb/env.pan
+++ b/features/lb/env.pan
@@ -2,7 +2,7 @@
 
 unique template features/lb/env;
 
-variable LB_PROFILE_SCRIPT ?= GLITE_LOCATION + '/etc/lb.conf';
+variable LB_PROFILE_SCRIPT ?= EMI_LOCATION + '/etc/lb.conf';
 
 # Use same variable names and default values for WMS and LB to ensure consistency if both 
 # run on the same machine, whichever is included first.

--- a/features/lb/glitestartup.pan
+++ b/features/lb/glitestartup.pan
@@ -1,0 +1,13 @@
+# Base configuration of glitestartup configuration module for LB usage.
+# Does not define the list of service to restart.
+
+unique template features/lb/glitestartup;
+
+include { 'components/glitestartup/config' };
+'/software/components/glitestartup/configFile'='/etc/gLiteservices';
+'/software/components/glitestartup/dependencies/pre' = glitestartup_add_dependency(list('accounts','dirperm','mysql','profile'));
+'/software/components/glitestartup/restartEnv' = push(LB_PROFILE_SCRIPT);
+"/software/components/glitestartup/scriptPaths" = list("/etc/init.d");
+# FIXME : remove when glitestartup support defining a list of service to restart
+'/software/components/glitestartup/restartServices' = true;
+

--- a/features/lb/locallogger.pan
+++ b/features/lb/locallogger.pan
@@ -1,3 +1,4 @@
+# Template to configure a LB locallogger on a machine other than the LB for WMS
 
 unique template features/lb/locallogger;
 
@@ -10,37 +11,23 @@ include { 'features/lb/env' };
 # Add gLite user
 include { 'users/glite' };
 
-# Do a copy of machine cert/key for locallogger usage
-'/software/components/filecopy/services' = {
-  SELF[escape(WMS_HOST_KEY)] = nlist('source', SITE_DEF_HOST_KEY,
-                                       'owner', GLITE_USER+':'+GLITE_GROUP,
-                                       'perms', '0400',
-                                       );
-  SELF[escape(WMS_HOST_CERT)] = nlist('source', SITE_DEF_HOST_CERT,
-                                        'owner', GLITE_USER+':'+GLITE_GROUP,
-                                        'perms', '0644',
-                                        );
-  SELF;
-};
 
-# Add glite-lb-locallogger to chkconfig
+# Configure glite-lb-locallogger startup
+include { 'features/lb/glitestartup' };
+'/software/components/glitestartup/services' = glitestartup_mod_service(LOCALLOGGER_SERVICE);
 
+# Ensure it is not enabled in chkconfig (it used to be in Quattor config).
+# Can be removed in the future (4/9/2014)
 include { 'components/chkconfig/config' };
-
 prefix '/software/components/chkconfig';
-
 'service' = {
-  SELF[LOCALLOGGER_SERVICE] = nlist('on','',
-                                   'startstop',true);
+  SELF[LOCALLOGGER_SERVICE] = nlist('off','');
   SELF;
 };
 
 # Fix /var/run/glite ownership
-
 include { 'components/dirperm/config' };
-
 prefix '/software/components/dirperm';
-
 'paths' = append(
   nlist(
     'owner','glite:glite',


### PR DESCRIPTION
Fixes #79

I confirm tthat `glitestartup` configuration module is useless on a CREAM CE. And this template is not used on the LB but only on the CREAM CE (or other services who may want to configure a locallogger).
