### PR TITLE
Fix some gip issue with MPI and VOMS services

### DIFF
--- a/features/gip/mpi.pan
+++ b/features/gip/mpi.pan
@@ -22,8 +22,10 @@ variable MPI_RUNTIMEENV = {
   # MPI-2 implementations.
   SELF[length(SELF)] = "OPENMPI";
   SELF[length(SELF)] = "OPENMPI-"+MPI_OPENMPI_VERSION;
-  SELF[length(SELF)] = "MPICH2";
-  SELF[length(SELF)] = "MPICH2-"+MPI_MPICH2_VERSION;
+  if(is_defined(MPI_USE_MPICH2) && MPI_USE_MPICH2){
+	SELF[length(SELF)] = "MPICH2";
+  	SELF[length(SELF)] = "MPICH2-"+MPI_MPICH2_VERSION;
+  };
 
   # Shared home directories support
   if ( is_defined(CE_SHARED_HOMES) ) {

--- a/features/gip/voms.pan
+++ b/features/gip/voms.pan
@@ -18,6 +18,8 @@ get_owner = echo $VOMS_VO
 get_acbr = echo VO:$VOMS_VO
 get_data = echo
 get_services = echo
+get_implementationname = echo VOMS
+get_implementationversion = rpm -q --qf %{V} voms-server
 EOF
 
 'confFiles/{/etc/bdii/gip/glite-info-service-voms-admin.conf}'= <<EOF;


### PR DESCRIPTION
Hi,

This is a fix for 2 GIP issues
- MPICH2 was publish even if not installed on cluster
- VOMS server not publish the Glue2ImplementationVersion and Glue2ImplementationName
