### PR TITLE
Add a script to remove Running "zombie" job on CREAM-CE

### DIFF
--- a/personality/cream_ce/config.pan
+++ b/personality/cream_ce/config.pan
@@ -136,6 +136,16 @@ variable CREAM_DATA_SOURCE_FACTORY_CLASS ?= 'org.apache.commons.dbcp.BasicDataSo
 # Create BLParser environment config file (used by CREAM submission)
 include { 'features/blparser/blah-config' };
 
+#-----
+# Add a script to purge running job that are keeped on cream_ce
+#----
+variable CREAM_PURGE_RUNNING_ENABLE ?= false;
+include { if (CREAM_PURGE_RUNNING_ENABLE) {
+    'personality/cream_ce/purge-running';
+  } else {
+    null;
+  };
+};
 #-----------------------------------------------------------------------------
 # Configuration for GLEXEC.
 #-----------------------------------------------------------------------------

--- a/personality/cream_ce/purge-running.pan
+++ b/personality/cream_ce/purge-running.pan
@@ -1,0 +1,18 @@
+unique template personality/cream_ce/purge-running;
+
+variable CREAM_PURGE_RUNNING_DATE ?= '5';
+variable CREAM_PURGE_IDLE_DATE ?= '10';
+
+include { 'components/cron/config' };
+
+'/software/components/cron/entries'=push(
+  nlist(
+    'command',   'env '+
+                 'CATALINA_HOME=/usr/share/tomcat6 '+
+                format('/usr/sbin/JobDBAdminPurger.sh -s RUNNING,%s:REALLY-RUNNING,%s:IDLE,%s',CREAM_PURGE_RUNNING_DATE,CREAM_PURGE_RUNNING_DATE,CREAM_PURGE_IDLE_DATE),
+    'frequency', '0 5 * * *',
+    'name',      'purgeCreamRunning',
+    'user',      'root',
+  ),  
+);
+


### PR DESCRIPTION
Hi,

This PR add a script to purge on CREAM-CE database all job flags as RUNNING / REALLY-RUNNING / IDLE but was probably no more on batch system.

By default, all RUNNING state older than 5 days and all IDLE state older than 10 days are deleted.
