### PR TITLE
Fix privacy issue with default xrootd monitoring/reporting config

### DIFF
--- a/personality/xrootd/config_federation.pan
+++ b/personality/xrootd/config_federation.pan
@@ -136,10 +136,29 @@ include { 'personality/xrootd/env_federation' };
 
       # Configure Xrootd monitoring if destination hosts are specified
       if ( is_defined(params['monitoring_host']) ) {
-        SELF[federation]['monitoringOptions'] = XROOTD_MONITORING_OPTIONS + ' ' + params['monitoring_host'];
+        if ( is_defined(params['monitoring_options']) ) {
+          monitoring_options = params['monitoring_options'];
+        } else {
+          monitoring_options = XROOTD_MONITORING_OPTIONS;
+        };
+        if ( is_defined(params['monitoring_events']) ) {
+          monitoring_events = params['monitoring_events'];
+        } else {
+          monitoring_events = XROOTD_MONITORING_EVENTS;
+        };
+        monitoring_events_str = '';
+        foreach (k;event;monitoring_events) {
+           monitoring_events_str = monitoring_events_str + ' ' + event;
+        };
+        SELF[federation]['monitoringOptions'] = format('%s dest %s %s', monitoring_options, monitoring_events_str, params['monitoring_host']);
       };
       if ( is_defined(params['reporting_host']) ) {
-        SELF[federation]['reportingOptions'] = params['reporting_host'] + ' ' + XROOTD_REPORTING_OPTIONS;
+        if ( is_defined(params['reporting_options']) ) {
+          reporting_options = params['reporting_options'];
+        } else {
+          reporting_options = XROOTD_REPORTING_OPTIONS;
+        };
+        SELF[federation]['reportingOptions'] = params['reporting_host'] + ' ' + reporting_options;
       };
     };
   };

--- a/personality/xrootd/env.pan
+++ b/personality/xrootd/env.pan
@@ -24,8 +24,11 @@ variable XROOTD_SITE_NAME ?= {
   site_name;
 };
 
-# Default monitoring options, when enabled
-variable XROOTD_MONITORING_OPTIONS ?= 'all 32k flush 30s  window 5s dest files info user redir';
+# Default monitoring options to use if none are defined in the federation parameters or if
+# there are several federations configured with monitoring enabled.
+variable XROOTD_MONITORING_OPTIONS ?= 'all flush io 30s ident 5m fstat 60 lfn ops xfr 5 mbuff 8k rbuff 4k rnums 3 window 5s';
+# Other default values for monitoring and reporting
+variable XROOTD_MONITORING_EVENTS ?= list('files','io','info','user','redir'); 
 variable XROOTD_REPORTING_OPTIONS ?= 'every 60s all -buff -poll sync';
 # Monitoring destinations: both must be lists
 variable XROOTD_MONITORING_DESTINATIONS ?= undef;

--- a/personality/xrootd/env_federation.pan
+++ b/personality/xrootd/env_federation.pan
@@ -5,6 +5,7 @@
 unique template personality/xrootd/env_federation;
 
 # Default parameters for some well known federations.
+# For LHC VOs, the reference information is at https://svnweb.cern.ch/trac/lcgdm/wiki/Dpm/Xroot/ManualSetup.
 # The key is a VO name.
 variable XROOTD_FEDERATION_PARAMS_DEFAULT = {
   SELF['atlas'] = nlist('instance', 'atlasfed',
@@ -12,7 +13,10 @@ variable XROOTD_FEDERATION_PARAMS_DEFAULT = {
                         'local_port', 11000,
                         'fedredir', undef,
                         'monitoring_host', 'atlas-fax-eu-collector.cern.ch:9930',
+                        'monitoring_options', 'all rbuff 32k flush 30s fstat 60 lfn ops xfr 5 window 5s',
+                        'monitoring_events', list('fstat','info','user','redir'),
                         'reporting_host', 'atl-prod05.slac.stanford.edu:9931',
+                        'reporting_options', 'every 60s all -buff -poll sync',
                         'xrd_mgr_port', 1094,
                         'n2n_library', 'XrdOucName2NameLFC.so',
 #                        Normally retrieved from AGIS but can be used to override AGIS definition
@@ -34,8 +38,11 @@ variable XROOTD_FEDERATION_PARAMS_DEFAULT = {
                         'cmsd_mgr_port', 1213,
                         'local_port', 11001,
                         'fedredir', undef,
-                        #'monitoring_host', 'xrd.report xrootd.t2.ucsd.edu:9930',
-                        #'reporting_host', 'xrd.report xrootd.t2.ucsd.edu:9931',
+                        'monitoring_host', 'xrootd.t2.ucsd.edu:9930',
+                        'monitoring_options', 'all flush io 30s ident 5m fstat 60 lfn ops xfr 5 mbuff 8k rbuff 4k rnums 3 window 5s',
+                        'monitoring_events', list('files','io','info','user','redir'),
+                        'reporting_host', 'xrootd.t2.ucsd.edu:9931',
+                        'reporting_options', 'every 60s all -buff -poll sync',
                         'xrd_mgr_port', 1094,
                         'n2n_library', 'libXrdCmsTfc.so',
                         'n2n_options', 'file:/etc/xrootd/storage.xml?protocol=direct',

--- a/personality/xrootd/monitoring.pan
+++ b/personality/xrootd/monitoring.pan
@@ -11,17 +11,6 @@ include { 'personality/xrootd/env_federation' };
 
 # Configure Xrootd monitoring on disk servers and local redirector if enabled for one federation
 
-# Configure Xrootd monitoring on disk servers and local redirector if enabled for one federation
-variable XROOTD_MONITORING_DESTINATIONS = {
-  foreach (i;federation;XROOTD_FEDERATION_LIST) {
-    params = XROOTD_FEDERATION_PARAMS[federation];
-    if ( is_defined(params['monitoring_host']) ) {
-      SELF[length(SELF)] = params['monitoring_host'];
-    };
-  };
-  SELF;
-};
-
 variable XROOTD_REPORTING_DESTINATIONS = {
   foreach (i;federation;XROOTD_FEDERATION_LIST) {
     params = XROOTD_FEDERATION_PARAMS[federation];
@@ -29,23 +18,78 @@ variable XROOTD_REPORTING_DESTINATIONS = {
       SELF[length(SELF)] = params['reporting_host'];
     };
   };
+  # No more than 2 hosts can be specified for the reporting directive
+  # in xrootd v3.
+  max_reporting_host = 2;
+  if ( length(SELF) > max_reporting_host ) {
+    error(format('Too many reporting hosts configured (maximum=%d)',max_reporting_host));
+  };
   SELF;
 };
 
 '/software/components/xrootd/options' = {
-  if ( length(XROOTD_MONITORING_DESTINATIONS) > 0 ) {
-    host_list = '';
-    foreach (i;host;XROOTD_MONITORING_DESTINATIONS) {
-      host_list = host_list + ' ' + host;
+  monitoring_dest = '';
+  max_monitoring_hosts = 2;
+  monitoring_host_num = 0;
+  if ( is_defined(XROOTD_MONITORING_DESTINATIONS) ) {
+    monitoring_host_num = length(XROOTD_MONITORING_DESTINATIONS);
+    if ( monitoring_host_num > max_monitoring_hosts ) {
+      error(format('Too many monitoring hosts configured (maximum=%d)',max_monitoring_host));
     };
-    SELF['monitoringOptions'] =  XROOTD_MONITORING_OPTIONS + ' ' + host_list;
+    event_list = '';
+    foreach (i;event;XROOTD_MONITORING_EVENTS) {
+      event_list = event_list + ' ' + event;
+    };
+    foreach (i;host;XROOTD_MONITORING_DESTINATIONS) {
+      monitoring_dest = monitoring_dest + ' ' + format('dest %s %s', event_list, host);
+    };
+    monitoring_options = XROOTD_MONITORING_OPTIONS;
+  } else if ( length(XROOTD_FEDERATION_LIST) > 0 ) {
+    debug(format('%s: one or several federations configured',OBJECT));
+    foreach (i;federation;XROOTD_FEDERATION_LIST) {
+      params = XROOTD_FEDERATION_PARAMS[federation];
+      if ( is_defined(params['monitoring_host']) ) monitoring_host_num = monitoring_host_num + 1;
+    };
+    if ( monitoring_host_num > max_monitoring_hosts ) {
+      error(format('Too many monitoring hosts configured (maximum=%d)',max_monitoring_host));
+    };
+    foreach (i;federation;XROOTD_FEDERATION_LIST) {
+      debug(format('%s: configuring monitoring for federation %s',OBJECT,federation));
+      params = XROOTD_FEDERATION_PARAMS[federation];
+      if ( is_defined(params['monitoring_host']) ) {
+        if ( !is_defined(params['monitoring_events']) ) {
+          params['monitoring_events'] = XROOTD_MONITORING_EVENTS;
+        };
+        if ( is_defined(params['monitoring_options']) ) {
+          monitoring_options = params['monitoring_options'];
+        } else {
+          monitoring_options = XROOTD_MONITORING_OPTIONS;
+        };
+        event_list = '';
+        foreach (k;event;params['monitoring_events']) {
+          event_list = event_list + ' ' + event;
+        };
+        monitoring_dest = monitoring_dest + ' ' + format('dest %s %s', event_list, params['monitoring_host']);
+      };
+    };
+    # Use federation monitoring options if there is only one configured, else the global variable
+    if ( monitoring_host_num > 1 ) {
+      debug(format('%s: more than one federation with monitoring enabled, using global monitoring options',OBJECT));
+      monitoring_options = XROOTD_MONITORING_OPTIONS;
+    };
+  };
+  if ( monitoring_host_num > 0 ) {
+    SELF['monitoringOptions'] = monitoring_options + ' ' + monitoring_dest;
   };
   if ( length(XROOTD_REPORTING_DESTINATIONS) > 0 ) {
     host_list = '';
     foreach (i;host;XROOTD_REPORTING_DESTINATIONS) {
-      host_list = host_list + ' ' + host;
+      if ( length(host_list) > 0 ) host_list = host_list + ',';
+      host_list = host_list + host;
     };
-    SELF['reportingOptions'] =  host_list + ' ' + XROOTD_REPORTING_OPTIONS;
+    # FIXME: use federation reporting options if there is only one configured, else the global variable
+    reporting_options = XROOTD_REPORTING_OPTIONS;
+    SELF['reportingOptions'] =  host_list + ' ' + reporting_options;
   };
   SELF; 
 };


### PR DESCRIPTION
The default monitoring/reporting configuration recommended so far by LHC experiments and used in Quattor had a privacy issue (user DN reported). This modification implements the recommended changes, see:
- https://twiki.cern.ch/twiki/bin/view/AtlasComputing/FAXproxyNew#Xrootd_configuration
- https://svnweb.cern.ch/trac/lcgdm/wiki/Dpm/Xroot/Setup#ATLASmonitoringonly
