### PR TITLE
blparser: do not set log file group to tomcat if not on a CE

### DIFF
--- a/features/blparser/blah-config.pan
+++ b/features/blparser/blah-config.pan
@@ -101,15 +101,18 @@ variable BLAH_CONFIG_FILE_RESTART = if ( FULL_HOSTNAME == BLPARSER_HOST ) {
         )
   );
 
-#manage accountinr dir == don't loose data
+# Allow tomcat to write in BLAH_LOG_DIR on CEs (else accounting will be lost)
 include { 'components/dirperm/config' };
-'/software/components/dirperm/paths' = 
-  push(nlist('path',BLAH_LOG_DIR,
-             'owner','root:tomcat' ,
-             'perm','0770',
-             'type','d'
-       )
-  );
+'/software/components/dirperm/paths' = {
+  if ( index(FULL_HOSTNAME,CE_HOSTS) >= 0 ) {
+    append(nlist('path',BLAH_LOG_DIR,
+                 'owner','root:tomcat' ,
+                 'perm','0770',
+                 'type','d'
+                ));
+  };
+  SELF;
+};
 
 include { 'components/profile/config' };
 '/software/components/profile' = component_profile_add_env(GLITE_GRID_ENV_PROFILE, nlist('BLAH_CONFIG_LOCATION',BLAH_CONF_FILE));


### PR DESCRIPTION
tomcat user/group exists only on CEs.

This PR **must** be part of 14.10. This seems to be an old bug, strange that nobody reported it yet... basically prevent proper configuration of a batch system on a machine different from the CE.
