### PR TITLE
gridftp: ensure that lcas-lcmaps-gt4-interface is installed

### DIFF
--- a/features/gridftp/rpms/config.pan
+++ b/features/gridftp/rpms/config.pan
@@ -5,3 +5,4 @@ prefix '/software/packages';
 '{globus-gridftp-server}'           = nlist();
 '{glite-initscript-globus-gridftp}' = nlist();
 '{globus-gridftp-server-progs}'     = nlist();
+'{lcas-lcmaps-gt4-interface}'     = nlist();


### PR DESCRIPTION
Old bug affecting usage of gridftp outside of a CE or WMS. Suggest inclusion in 14.10 (https://github.com/quattor/release/issues/63).
