### PR TITLE
Add multicore support for APEL

### DIFF
--- a/features/accounting/apel/base.pan
+++ b/features/accounting/apel/base.pan
@@ -27,3 +27,6 @@ variable APEL_DB_PWD ?= if ( exists(APELDB_PWD) && is_defined(APELDB_PWD) ) {
                                          );
   SELF;
 };
+
+# Set to true if the cluster has multicore resources available
+variable APEL_MULTICORE_ENABLED ?= true;

--- a/features/accounting/apel/parser_blah.pan
+++ b/features/accounting/apel/parser_blah.pan
@@ -71,7 +71,7 @@ include {'components/metaconfig/config'};
             'enabled', to_string(match(FULL_HOSTNAME, LRMS_SERVER_HOST)),
             'reparse', 'false',
             'type', 'PBS',
-            'parallel', 'false',
+            'parallel', to_string(APEL_MULTICORE_ENABLED),
             'dir', TORQUE_CONFIG_DIR + '/server_priv/accounting',
             'filename_prefix', '20',
             'subdirs', 'false',

--- a/features/accounting/apel/parser_pbs.pan
+++ b/features/accounting/apel/parser_pbs.pan
@@ -75,7 +75,7 @@ include {'components/metaconfig/config'};
             'enabled', to_string(match(FULL_HOSTNAME, LRMS_SERVER_HOST)),
             'reparse', 'false',
             'type', 'PBS',
-            'parallel', 'false',
+            'parallel', to_string(APEL_MULTICORE_ENABLED),
             'dir', TORQUE_CONFIG_DIR + '/server_priv/accounting',
             'filename_prefix', '20',
             'subdirs', 'false',


### PR DESCRIPTION
As discussed on the lcg-tech mailing, it is required to be able to set the value of batch->parallel to true if the cluster offers multicore ressources. It fixes the #116 issue.
By default, it does not change the configuration (the option is set to false).
