### PR TITLE
Use the TORQUE_CONFIG_DIR variable to place the myinit.sh script

### DIFF
--- a/features/torque2/server/config.pan
+++ b/features/torque2/server/config.pan
@@ -86,15 +86,15 @@ variable PBS_AUTHORIZED_USERS_SCRIPT ?= {
   contents;
 #"#! /bin/bash\nqmgr -c 'set server authorized_users =*@"+CE_HOST+"'\n";
 };
-
+variable TORQUE_MYINIT_SCRIPT ?= TORQUE_CONFIG_DIR + '/myinit.sh';
 "/software/components/filecopy/services" = {
-         SELF[escape(TORQUE_CONFIG_DIR+"myinit.sh")]=
+         SELF[escape(TORQUE_MYINIT_SCRIPT)]=
         nlist("config",PBS_AUTHORIZED_USERS_SCRIPT,
               "perms", "0700",
-             "owner", "root",
+              "owner", "root",
               "group","root",
-              "restart",TORQUE_CONFIG_DIR+"myinit.sh",
-	"forceRestart",true,
+              "restart",TORQUE_MYINIT_SCRIPT,
+	      "forceRestart",true,
         );
          SELF;
        };

--- a/features/torque2/server/config.pan
+++ b/features/torque2/server/config.pan
@@ -88,12 +88,12 @@ variable PBS_AUTHORIZED_USERS_SCRIPT ?= {
 };
 
 "/software/components/filecopy/services" = {
-         SELF[escape("/var/torque/myinit.sh")]=
+         SELF[escape(TORQUE_CONFIG_DIR+"myinit.sh")]=
         nlist("config",PBS_AUTHORIZED_USERS_SCRIPT,
               "perms", "0700",
              "owner", "root",
               "group","root",
-              "restart","/var/torque/myinit.sh",
+              "restart",TORQUE_CONFIG_DIR+"myinit.sh",
 	"forceRestart",true,
         );
          SELF;


### PR DESCRIPTION
With the version torque 2.5.13-1cri.9nik.el6 the configuration directory is /var/spool/pbs, which differs from /var/torque. Use the TORQUE_CONFIG_DIR variable to place the myinit.sh script.