### PR TITLE
Fix LBSERVER status and rpm version checks

### DIFF
--- a/features/gip/lb.pan
+++ b/features/gip/lb.pan
@@ -20,10 +20,9 @@ variable GIP_PROVIDER_WRAPPER_LB ?= 'glite-info-service-lbserver';
     SELF['confFiles'][escape(GIP_PROVIDER_SERVICE_CONF_LB)] = 
         "init = "+GIP_PROVIDER_SERVICE_INIT_LB+"\n" +
         "service_type = "+GIP_PROVIDER_SERVICE_TYPE_LB+"\n" +
-        "get_version = rpm -q  glite-lb-ws-interface --queryformat '%{version}\\n'\n" +
+        "get_version = rpm -qa | grep 'glite-lb-server-[0-9]' | cut -d- -f4\n" +
         "get_endpoint = echo  https://${LBSERVER_HOST}:${LBSERVER_PORT}/\n" +
-        "get_status = " + GIP_SCRIPTS_DIR + "/glite-info-service-test LBSERVER && " +
-            GLITE_LOCATION + "/etc/init.d/glite-lb-bkserverd status\n"+
+        "get_status = " + GIP_SCRIPTS_DIR + "/glite-info-service-test LBSERVER && /etc/init.d/glite-lb-bkserverd status\n"+
         "WSDL_URL = echo http://trinity.datamat.it/projects/EGEE/WMProxy/WMProxy.wsdl\n" +
         "semantics_URL = echo https://edms.cern.ch/file/571273/2/LB-guide.pdf\n" +
         "get_starttime =  perl -e '@st=stat($ENV{LBSERVER_PID_FILE});print \"@st[10]\\n\";'\n" +


### PR DESCRIPTION
With the previous code, GlueServiceStatus and GlueServiceVersion were published with wrong values ('Other' and 4.4.4.4). The fix permits to publish correct values (see http://gstat2.grid.sinica.edu.tw/gstat/ldap/browse?host=ldap://sbgbdii1.in2p3.fr:2170/&entry=true&dn=glueserviceuniqueid=sbgwms1.in2p3.fr_org.glite.lb.server,mds-vo-name=IN2P3-IRES,o=grid).