### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 template-library-grid
 =====================
 
-Template library for configuring EMI grid middleware services
+Template library for configuring EMI grid middleware services.
 
 EMI services validated (9/9/2014): APEL, ARGUS, BDII, CREAM CE, DPM, LB, LFC, MyProxy, Torque, UI, WLCG VOBOX, VOMS, WMS, WN, Xrootd
 


### PR DESCRIPTION
The real reason for this PR is to allow testing `get-template-library` developments. Please keep it open until further notice...