### PR TITLE
The /etc/lrms/lcg-info-dynamic-maui.defaults file should be readable by any

### DIFF
--- a/features/gip/ce-maui-plugin-defaults.pan
+++ b/features/gip/ce-maui-plugin-defaults.pan
@@ -17,7 +17,7 @@ include 'components/metaconfig/config';
   if ( !is_defined(SELF['dependencies']['post']) ) SELF['dependencies']['post'] = list();
   SELF['dependencies']['post'][length(SELF['dependencies']['post'])] = 'gip2';
   service_id = escape(GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE);
-  SELF['services'][service_id]['mode'] = 0600;
+  SELF['services'][service_id]['mode'] = 0644;
   SELF['services'][service_id]['owner'] = 'root';
   SELF['services'][service_id]['group'] = 'root';
   SELF['services'][service_id]['module'] = 'tiny';


### PR DESCRIPTION
It fixes the bug https://github.com/quattor/template-library-grid/issues/148