### PR TITLE
Slot reporting

### DIFF
--- a/defaults/grid/config.pan
+++ b/defaults/grid/config.pan
@@ -1185,17 +1185,27 @@ variable WN_CPU_CONFIG = {
     };
     cpu_num = length(wn_hw['cpu']);
     core_num =0;
+    slot_num =0;
     if ( cpu_num > 0 ) {
       if ( is_defined(WN_CPUS[wn]) ) {
         core_num = WN_CPUS[wn];
+        slot_num = core_num;
       } else if ( is_defined(wn_hw['cpu'][0]['cores']) ) {
         core_num = cpu_num * wn_hw['cpu'][0]['cores'];
+        slot_num = core_num;
+
+        # If hyperthreading is set to true, gives slots = 2 * cores
+        if ( is_defined(wn_hw['cpu'][0]['hyperthreading']) && wn_hw['cpu'][0]['hyperthreading']  ) {
+          slot_num = slot_num * 2;
+        };
       } else {
         core_num = WN_CPUS_DEF;
+        slot_num = core_num;
       };
     };
     SELF[wn] = nlist('cpus', cpu_num,
                      'cores', core_num,
+                     'slots', slot_num,
                     );
   };
   

--- a/features/gip/ce.pan
+++ b/features/gip/ce.pan
@@ -303,10 +303,12 @@ variable CE_BATCH_SYS_LIST ?= {
 variable CE_CPU_CONFIG = {
   SELF['cpus'] = 0;
   SELF['cores'] = 0;
+  SELF['slots'] = 0;
   foreach (i;wn;WORKER_NODES) {
     if ( is_defined(WN_CPU_CONFIG[wn]) ) {
       SELF['cpus'] = SELF['cpus'] + WN_CPU_CONFIG[wn]['cpus'];
       SELF['cores'] = SELF['cores'] + WN_CPU_CONFIG[wn]['cores'];
+      SELF['slots'] = SELF['slots'] + WN_CPU_CONFIG[wn]['slots'];
     } else {
       error('Failed to find '+wn+' CPU configuration in WN_CPU_CONFIG');
     };

--- a/features/gip/ce.pan
+++ b/features/gip/ce.pan
@@ -335,7 +335,7 @@ variable GIP_CE_PLUGIN_COMMAND = {
     } else {
       pythonbin = 'python'
     };
-    gip_script_options = format("--max-normal-slots %d --defaults %s", CE_CPU_CONFIG['cores'], GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE);
+    gip_script_options = format("--max-normal-slots %d --defaults %s", CE_CPU_CONFIG['slots'], GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE);
     SELF['ce'] = pythonbin + ' ' + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-maui --host "+LRMS_SERVER_HOST+" "+gip_script_options;
     # FIXME: lcg-info-dynamic-scheduler doesn't allow to use a LDIF file in a non standard location...
     # Update to whatever is appropriate in cache mode when this is fixed.
@@ -602,7 +602,7 @@ variable GIP_CE_LDIF_PARAMS = {
   
     # For GlueHostArchitecturePlatformType, assume the same type as CE until we support several subclusters
     # per cluster.
-    average_core_num = to_double(CE_CPU_CONFIG['cores']) / CE_CPU_CONFIG['cpus'];
+    average_core_num = to_double(CE_CPU_CONFIG['slots']) / CE_CPU_CONFIG['cpus'];
     hepspec06 = 4 * to_double(CE_SI00) / 1000;
     cluster_entries_g1[escape('dn: GlueSubClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST+', GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST+',Mds-Vo-name=resource,o=grid')] = 
       nlist(
@@ -629,7 +629,7 @@ variable GIP_CE_LDIF_PARAMS = {
             'GlueHostProcessorVendor',          list(CE_CPU_VENDOR),
             'GlueSubClusterName',               list(FULL_HOSTNAME),
             'GlueSubClusterPhysicalCPUs',       list(to_string(CE_CPU_CONFIG['cpus'])),
-            'GlueSubClusterLogicalCPUs',        list(to_string(CE_CPU_CONFIG['cores'])),
+            'GlueSubClusterLogicalCPUs',        list(to_string(CE_CPU_CONFIG['slots'])),
             'GlueSubClusterTmpDir',             list('/tmp'),
             'GlueSubClusterWNTmpDir',           list('/tmp'),
             "GlueInformationServiceURL", list(RESOURCE_INFORMATION_URL),
@@ -1049,7 +1049,7 @@ variable GIP_CE_LDIF_PARAMS = {
     glue2_var_prefix = format('ExecutionEnvironment_%s_',GIP_CLUSTER_PUBLISHER_HOST);
     SELF['glue2']['ExecutionEnvironment'] = nlist(glue2_var_prefix+'ArchitecturePlatformType', list(CE_WN_ARCH),
                                                   glue2_var_prefix+'PhysicalCPUs', list(to_string(CE_CPU_CONFIG['cpus'])),
-                                                  glue2_var_prefix+'LogicalCPUs', list(to_string(CE_CPU_CONFIG['cores'])),
+                                                  glue2_var_prefix+'LogicalCPUs', list(to_string(CE_CPU_CONFIG['slots'])),
                                                   glue2_var_prefix+'SmpSize', list(CE_SMPSIZE),
                                                   glue2_var_prefix+'ProcessorVendor', list(CE_CPU_VENDOR),
                                                   glue2_var_prefix+'ProcessorModel', list(CE_CPU_MODEL),

--- a/features/maui/server/config.pan
+++ b/features/maui/server/config.pan
@@ -416,8 +416,8 @@ variable MAUI_CONFIG ?= {
     };
     
     # Compute the number of slots dedicated to SR.
-    if ( MAUI_USE_HW_CONFIG && exists(WN_CPU_CONFIG[wn]['cores']) && is_defined(WN_CPU_CONFIG[wn]['cores']) ) {
-      process_slots = to_long(WN_CPU_CONFIG[wn]['cores']);
+    if ( MAUI_USE_HW_CONFIG && exists(WN_CPU_CONFIG[wn]['slots']) && is_defined(WN_CPU_CONFIG[wn]['slots']) ) {
+      process_slots = to_long(WN_CPU_CONFIG[wn]['slots']);
     } else if ( exists(WN_CPUS[wn]) && is_defined(WN_CPUS[wn]) ) {
       process_slots = to_long(WN_CPUS[wn]);
     } else {

--- a/features/torque2/server/config.pan
+++ b/features/torque2/server/config.pan
@@ -334,8 +334,8 @@ variable CE_QUEUE_STATE_DEFAULTS ?= {
     wn_attrs = WN_ATTRS;
   };
   foreach (i;wn;WORKER_NODES) {
-    if ( TORQUE_USE_HW_CONFIG && exists(WN_CPU_CONFIG[wn]['cores']) && is_defined(WN_CPU_CONFIG[wn]['cores']) ) {
-      process_slots = to_long(WN_CPU_CONFIG[wn]['cores']);
+    if ( TORQUE_USE_HW_CONFIG && exists(WN_CPU_CONFIG[wn]['slots']) && is_defined(WN_CPU_CONFIG[wn]['slots']) ) {
+      process_slots = to_long(WN_CPU_CONFIG[wn]['slots']);
     } else if ( exists(WN_CPUS[wn]) && is_defined(WN_CPUS[wn]) ) {
       process_slots = to_long(WN_CPUS[wn]);
     } else {


### PR DESCRIPTION
Hi,

   added #slots on top of #cores in WN_CPU_CONFIG & CE_CPU_CONFIG, for cases of CPUs with hyperthreading. So the information of the number of physical & logical cores(= # slots) are both present. Reporting is done on #slots, which is by default the same as #cores if boolean hyperthreading is not set in any /hardware/cpu.

Behaviour should not change for sites as long as they don't set hyperthreading to true.

Cheers
Romain