### PR TITLE
conf for new puppet modules

### DIFF
--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -4,7 +4,7 @@ include {'components/puppet/config'};
 
 '/software/components/puppet/puppetconf/main/parser' = 'future';
 
-include {'quattor/functions/strings'};
+include {'quattor/functions/package'};
 
 #Including the needed modules
 variable DPM_PUPPET_MODULE_VERSION ?= "1.8.9";
@@ -24,7 +24,7 @@ variable DPMMGR_UID?=970;
 
 	self[escape("dpm::params::volist")] = VOS;
 
-	if(comparever(DPM_PUPPET_MODULE_VERSION,'1.8.10')>0){
+	if(pkg_compare_version(DPM_PUPPET_MODULE_VERSION,'1.8.10')>0){
 	  disk_list='';
 	  foreach(i;disk;DPM_HOSTS['disk']){
 	    if(disk_list==''){

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -4,8 +4,10 @@ include {'components/puppet/config'};
 
 '/software/components/puppet/puppetconf/main/parser' = 'future';
 
+include {'quattor/functions/strings'};
+
 #Including the needed modules
-variable DPM_PUPPET_MODULE_VERSION ?= "0.0.13";
+variable DPM_PUPPET_MODULE_VERSION ?= "1.8.9";
 "/software/components/puppet/modules/{sartiran-dpm}" = nlist("version",DPM_PUPPET_MODULE_VERSION);
 
 variable DPMMGR_UID?=970;
@@ -22,14 +24,19 @@ variable DPMMGR_UID?=970;
 
 	self[escape("dpm::params::volist")] = VOS;
 
-	disk_list='';
-	foreach(i;disk;DPM_HOSTS['disk']){
-		if(disk_list==''){
-			disk_list=disk;
-		}else{
-			disk_list=disk_list+' '+disk;
-		};
+	if(comparever(DPM_PUPPET_MODULE_VERSION,'1.8.10')>0){
+	  disk_list='';
+	  foreach(i;disk;DPM_HOSTS['disk']){
+	    if(disk_list==''){
+	      disk_list=disk;
+	    }else{
+	      disk_list=disk_list+' '+disk;
+	    };
+	  };
+        }else{
+          disk_list=DPM_HOSTS['disk'];
 	};
+
 	self[escape("dpm::params::disk_nodes")] = disk_list;
 
 	self[escape("dpm::params::dpmmgr_uid")] = DPMMGR_UID;
@@ -38,6 +45,7 @@ variable DPMMGR_UID?=970;
 	self[escape("dpm::params::token_password")] = 'mytokenpassword';
 	self[escape("dpm::params::xrootd_sharedkey")] = DPM_XROOTD_SHARED_KEY;
 	self[escape("dpm::params::db_pass")] = DPM_DB_PARAMS['password'];
+
 	self[escape("dpm::params::mysql_root_pass")] = DPM_DB_PARAMS['adminpwd'];
 	self[escape("dpm::params::dpm_xrootd_fedredirs")] = XROOTD_FEDERATION_PARAMS;
 
@@ -55,6 +63,14 @@ variable DPMMGR_UID?=970;
 		if(is_defined(DPM_MEMCACHED_ENABLED) && DPM_MEMCACHED_ENABLED){
 				self[escape("dpm::params::memcached_enabled")] = true;
 		};
+	};
+
+	if(is_defined(GRIDFTP_REDIR_ENABLED) && GRIDFTP_REDIR_ENABLED){
+		self[escape("dpm::params::gridftp_redirect")] = true;
+	};
+
+	if(is_defined(SPACE_REPORTING_ENABLED) && SPACE_REPORTING_ENABLED){
+		self[escape("dpm::params::enable_space_reporting")] = true;
 	};
 
 	self;

--- a/personality/se_dpm/rpms/config.pan
+++ b/personality/se_dpm/rpms/config.pan
@@ -6,6 +6,7 @@ variable SEDPM_USE_METAPACKAGES ?= if ( is_defined(REPOSITORY_EPEL_TESTING_ENABL
                                    } else {
                                      true;
                                    };
+variable SEDPM_MEMCACHE_ENABLED ?= false;
 
 '/software/packages/' = {
   if ( SEDPM_USE_METAPACKAGES ) {
@@ -47,6 +48,12 @@ variable SEDPM_USE_METAPACKAGES ?= if ( is_defined(REPOSITORY_EPEL_TESTING_ENABL
       SELF[escape('dpm-srm-server-mysql')] = nlist();
       SELF[escape('dmlite-plugins-mysql')] = nlist();
       SELF[escape('glite-info-provider-service')] = nlist();
+      SELF[escape('dpm-contrib-admintools')] = nlist();
+      SELF[escape('argus-pep-api-c')] = nlist();
+      if ( SEDPM_MEMCACHE_ENABLED ){
+        SELF[escape('dmlite-plugins-memcache')] = nlist();
+        SELF[escape('memcached')] = nlist();
+      }
     };
 
   };


### PR DESCRIPTION
Some fixes for making the DPM configuration via ncm-puppet compatible with the last versions of modules (this is the configuration running at GRIF since quite a while)
