### PR TITLE
support for SUBMIT REQUESTS

### DIFF
--- a/features/htcondor/params.pan
+++ b/features/htcondor/params.pan
@@ -17,7 +17,7 @@ variable CONDOR_CONFIG = {
 
   # Condor version is used to a RPM packaging change in condor 8.3
   if (!is_defined(SELF['version'])) {
-     SELF['version'] = '8.2';
+     SELF['version'] = '8.4';
   };
 
   if(!is_defined(SELF['pwd_hash'])){

--- a/features/htcondor/templ/head.pan
+++ b/features/htcondor/templ/head.pan
@@ -17,6 +17,12 @@ endif
 ROTATE_HISTORY_DAILY = true
 MAX_HISTORY_ROTATIONS = 10
 
+NEGOTIATOR_POST_JOB_RANK = \
+   (RemoteOwner =?= UNDEFINED) * \
+   (ifThenElse(isUndefined(Mips), 1000, Mips) - \
+   SlotID - 1.0e10*(Offline=?=True))
+
+
 EOF
 	foreach(i;opt;CONDOR_CONFIG['options']['head']){
 		txt = txt +  opt['name'] + ' = ' + opt['value'] + "\n"; 

--- a/features/htcondor/templ/submit.pan
+++ b/features/htcondor/templ/submit.pan
@@ -1,7 +1,7 @@
 structure template features/htcondor/templ/submit;
 
 'text' = {
-       txt = <<EOF;
+  txt = <<EOF;
 
 DAEMON_LIST = $(DAEMON_LIST) SCHEDD 
 
@@ -9,24 +9,47 @@ ROTATE_HISTORY_DAILY = true
 MAX_HISTORY_ROTATIONS = 1000
 
 EOF
-	foreach(i;opt;CONDOR_CONFIG['options']['submit']){
-		txt = txt +  opt['name'] + ' = ' + opt['value'] + "\n"; 
-	};
-	txt = txt + "\n";
+  foreach(i;opt;CONDOR_CONFIG['options']['submit']){
+    txt = txt +  opt['name'] + ' = ' + opt['value'] + "\n"; 
+  };
+  txt = txt + "\n";
 
-	first=true;
+  first=true;
 
-	foreach(name;rule;CONDOR_CONFIG['gc_rules']){
-	  if(first){
-	    txt = txt + "SYSTEM_PERIODIC_REMOVE = (" + rule +')\'+"\n";
-	    first=false;
-	  }else{
-	    txt = txt + '|| (' + rule + ')\'+"\n"; 
-	  };
-	};
+  foreach(name;rule;CONDOR_CONFIG['gc_rules']){
+    if(first){
+      txt = txt + "SYSTEM_PERIODIC_REMOVE = (" + rule +')\'+"\n";
+      first=false;
+    }else{
+      txt = txt + '|| (' + rule + ')\'+"\n"; 
+    };
+  };
 
-	txt = txt + "\n";
-	txt;
+  txt = txt + "\n";
+
+  if(is_defined(CONDOR_CONFIG['submit_rules']) && (length(CONDOR_CONFIG['submit_rules'])>0)){
+    txt = txt + 'SUBMIT_REQUIREMENT_NAMES =';
+
+    foreach(name;rule;CONDOR_CONFIG['submit_rules']){
+      txt= txt+ ' ' + name;
+    };
+
+    txt = txt + "\n";
+
+    foreach(name;rule;CONDOR_CONFIG['submit_rules']){
+      if(!is_defined(rule['rule'])){
+        error("rule CONDOR_CONFIG[submit_rules][" + name + "] is missing rule definition.");
+      };
+      txt = txt+ 'SUBMIT_REQUIREMENT_'+name+' = '+rule['rule'] + "\n";
+      if(is_defined(rule['reason'])){
+        txt = txt+ 'SUBMIT_REQUIREMENT_'+name+'_REASON = "'+rule['reason'] + '"'+"\n";
+      };
+    };  
+
+    txt = txt + "\n";
+  };
+
+  txt;
 };
 
 


### PR DESCRIPTION
support for defining SUBMIT REQUIREMENTS which are named rule to allow submission from a submit node. Useful for restricting the usage of one queue (e.g. muticore queue to multicore jobs) and to drain selectively one queue.
 