### PR TITLE
Change grid-voms.desy.de port

### DIFF
--- a/vo/params/icecube.pan
+++ b/vo/params/icecube.pan
@@ -6,7 +6,7 @@ structure template vo/params/icecube;
 'voms_servers' ?= list(
     nlist('name', 'grid-voms.desy.de',
           'host', 'grid-voms.desy.de',
-          'port', 15106,
+          'port', 15109,
           'adminport', 8443,
          ),
 );


### PR DESCRIPTION
Following the documentation (https://grid-voms.desy.de:8443/voms/icecube/configuration/configuration.action), the port used to contact this server should be 15109 (instead of 15106)