### PR TITLE
Globus: remove SASL_PATH env variable definition

### DIFF
--- a/features/globus/env.pan
+++ b/features/globus/env.pan
@@ -57,6 +57,5 @@ include { 'components/profile/config' };
                                                         GLOBUS_LOCATION+'/bin',
                                                        );
 "/software/components/profile/path/LD_LIBRARY_PATH/prepend" = push(GLOBUS_LOCATION+'/lib');
-"/software/components/profile/path/SASL_PATH/prepend" = push(GLOBUS_LOCATION+'/lib/sasl');
 "/software/components/profile/path/MANPATH/prepend" = push(GLOBUS_LOCATION+'/man');
 


### PR DESCRIPTION
- Definition incorrect: breaks the possibility to use standard SASL plugins

Fixes #177.