### PR TITLE
DPM: use PKG_VERSION_xxx for testing pkg_compare_version() return value

### DIFF
--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -33,7 +33,7 @@ variable DPMMGR_UID?=970;
 
 	self[escape('dpm::params::volist')] = VOS;
 
-	if(pkg_compare_version(DPM_PUPPET_MODULE_VERSION,'1.8.10')>0){
+	if ( pkg_compare_version(DPM_PUPPET_MODULE_VERSION,'1.8.10') == PKG_VERSION_LESS ) {
 	  disk_list='';
 	  foreach(i;disk;DPM_HOSTS['disk']){
 	    if(disk_list==''){


### PR DESCRIPTION
Requires https://github.com/quattor/template-library-core/pull/131 to be merged first... but would be good to merge at the same time.