### PR TITLE
defaults/grid/config: fix typo introducted in 7e39550

### DIFF
--- a/defaults/grid/config.pan
+++ b/defaults/grid/config.pan
@@ -427,7 +427,7 @@ variable CE_USE_SSH ?= undef;
 #   - torque2 : Torque v2 with MAUI
 #   - condor : HTCondor
 # Default is torque1 if CE_BATCH_SYS is defined to pbs (backward compatibility)
-variable CE_BATCH_NAME ?= if (exists(CE_BATCH_SYS) && is_defined(CE_BATCH_SYS) && match(CE_BATCH_SYS, "^(lcg)?pbs$"))) {
+variable CE_BATCH_NAME ?= if (exists(CE_BATCH_SYS) && is_defined(CE_BATCH_SYS) && match(CE_BATCH_SYS, "^(lcg)?pbs$")) {
     'torque1';
 } else {
     if (is_defined(CE_BATCH_SYS) && (CE_BATCH_SYS == "condor")) {


### PR DESCRIPTION
Fix a regression introduced in #7e395505e652eb6491574164cb528e0b718f65e3 preventing the template to compile successfully.

Showstopper for https://github.com/quattor/release/issues/278#issuecomment-270122186.