### PR TITLE
UMD-3 ncm-puppet: 'gid' and 'token password' should be configurable

### DIFF
--- a/features/puppet/config.pan
+++ b/features/puppet/config.pan
@@ -1,9 +1,6 @@
 unique template features/puppet/config;
 
-include {'components/puppet/config'};
-include {'components/spma/config'};
+include 'components/puppet/config';
+include 'components/spma/config';
 
-'/software/packages/{puppet}' ?= nlist();
-
-
-
+'/software/packages' = pkg_repl('puppet');

--- a/personality/se_dpm/puppet/bdii.pan
+++ b/personality/se_dpm/puppet/bdii.pan
@@ -1,21 +1,17 @@
 unique template personality/se_dpm/puppet/bdii;
 
-variable SE_HOSTS={
-        SELF[FULL_HOSTNAME]=nlist('type','SE_dpm');
-        SELF;
+variable SE_HOSTS = {
+    SELF[FULL_HOSTNAME] = dict('type', 'SE_dpm');
+    SELF;
 };
 
-variable BDII_TYPE='resource';
+variable BDII_TYPE ?= 'resource';
 
 variable GSIFTP_ENABLED ?= true;
 variable RFIO_ENABLED ?= true;
 variable SRMV2_ENABLED ?= true;
 variable XROOTD_ENABLED ?= true;
 
-
 include 'personality/bdii/service';
 include 'personality/se_dpm/puppet/info_user_proxy';
 include 'features/gip/se';
-
-
-

--- a/personality/se_dpm/puppet/federations.pan
+++ b/personality/se_dpm/puppet/federations.pan
@@ -1,15 +1,13 @@
 unique template personality/se_dpm/puppet/federations;
 
-
 '/software/packages/' = {
-  if(is_defined(XROOTD_FEDERATION_PARAMS)){
-     if(is_defined(XROOTD_FEDERATION_PARAMS['cms'])){
-       pkg_repl('xrootd-cmstfc');
-     };
-     if(is_defined(XROOTD_FEDERATION_PARAMS['atlas'])){
-       pkg_repl('xrootd-server-atlas-n2n-plugin');
-     };                        
-  };
-  SELF;
+    if(is_defined(XROOTD_FEDERATION_PARAMS)){
+        if(is_defined(XROOTD_FEDERATION_PARAMS['cms'])){
+            pkg_repl('xrootd-cmstfc');
+        };
+        if(is_defined(XROOTD_FEDERATION_PARAMS['atlas'])){
+            pkg_repl('xrootd-server-atlas-n2n-plugin');
+        };
+    };
+    SELF;
 };
-

--- a/personality/se_dpm/puppet/info_user_proxy.pan
+++ b/personality/se_dpm/puppet/info_user_proxy.pan
@@ -3,30 +3,28 @@
 
 unique template personality/se_dpm/puppet/info_user_proxy;
 
-variable SEDPM_INFO_USER ?= if ( is_defined(GIP_USER) ) {
-                              return(GIP_USER);
-                            } else {
-                              error('Variable GIP_USER must be configured');
-                            };
+variable GIP_USER ?= error('Variable GIP_USER must be configured');
+variable SEDPM_INFO_USER ?= GIP_USER;
 
-
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 # Proxy for resource BDII : a cron entry + a startup script to ensure
 # a valid proxy exists at boot time.
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 include 'components/cron/config';
 
 # Cron job to create hostproxy for GIP user (used by dynamic plugin)
 variable DPM_HOSTPROXY_CRON = SEDPM_INFO_USER + "-hostproxy";
 variable DPM_HOSTPROXY_TMP = GLITE_LOCATION_VAR + "/dpm/hostproxy.$$";
 variable DPM_HOSTPROXY_FILE = GLITE_LOCATION_VAR + "/dpm/hostproxy." + SEDPM_INFO_USER;
-variable DPM_HOSTPROXY_CMD = "mkdir -p /var/lib/ldap/.globus && /bin/cp /etc/grid-security/hostcert.pem /var/lib/ldap/.globus/usercert.pem && /bin/cp /etc/grid-security/hostkey.pem /var/lib/ldap/.globus/userkey.pem && chown -R "+SEDPM_INFO_USER + " /var/lib/ldap/.globus";
-"/software/components/cron/entries" =
-  push(nlist(
-    "name",DPM_HOSTPROXY_CRON,
-    "user","root",
-    "frequency", "AUTO 2,8,14,20 * * *",
-    "command", DPM_HOSTPROXY_CMD));
+variable DPM_HOSTPROXY_CMD = "mkdir -p /var/lib/ldap/.globus && /bin/cp /etc/grid-security/hostcert.pem /var/lib/ldap/.globus/usercert.pem && /bin/cp /etc/grid-security/hostkey.pem /var/lib/ldap/.globus/userkey.pem && chown -R " + SEDPM_INFO_USER + " /var/lib/ldap/.globus";
+"/software/components/cron/entries" = push(
+    dict(
+        "name", DPM_HOSTPROXY_CRON,
+        "user", "root",
+        "frequency", "AUTO 2,8,14,20 * * *",
+        "command", DPM_HOSTPROXY_CMD,
+    )
+);
 
 # Startup script to ensure a valid proxy at boot time (or when the command to generate it is changed
 include 'components/filecopy/config';
@@ -38,34 +36,35 @@ variable DPM_HOSTPROXY_STARTUP_CONTENTS = "#!/bin/sh\n" +
                                           "# description: BDII Service\n" +
                                           DPM_HOSTPROXY_CMD;
 '/software/components/filecopy/services' = {
-  SELF[escape(DPM_HOSTPROXY_STARTUP)] = nlist('config', DPM_HOSTPROXY_STARTUP_CONTENTS,
-                                              'perms', '0755',
-                                              'owner', 'root',
-                                              'restart', DPM_HOSTPROXY_STARTUP
-                                             );
-  SELF;
+    SELF[escape(DPM_HOSTPROXY_STARTUP)] = dict(
+        'config', DPM_HOSTPROXY_STARTUP_CONTENTS,
+        'perms', '0755',
+        'owner', 'root',
+        'restart', DPM_HOSTPROXY_STARTUP,
+    );
+    SELF;
 };
 '/software/components/chkconfig' = {
-  if ( index('filecopy',SELF['dependencies']['pre']) < 0 ) {
-    SELF['dependencies']['pre'][length(SELF['dependencies']['pre'])] = 'filecopy';
-  };
-  SELF['service'][DPM_HOSTPROXY_CRON]['on'] = "";
-  SELF;
+    if ( index('filecopy', SELF['dependencies']['pre']) < 0 ) {
+        SELF['dependencies']['pre'][length(SELF['dependencies']['pre'])] = 'filecopy';
+    };
+    SELF['service'][DPM_HOSTPROXY_CRON]['on'] = "";
+    SELF;
 };
 
-
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 # altlogrotate
-# ---------------------------------------------------------------------------- 
-include 'components/altlogrotate/config'; 
-
+# ----------------------------------------------------------------------------
+include 'components/altlogrotate/config';
 "/software/components/altlogrotate/entries" = {
-  SELF[DPM_HOSTPROXY_CRON] = nlist("pattern", "/var/log/"+DPM_HOSTPROXY_CRON+".ncm-cron.log",
-                                   "compress", true,
-                                   "missingok", true,
-                                   "frequency", "monthly",
-                                   "create", true,
-                                   "ifempty", true,
-                                   "rotate", 2);
-  SELF;
+    SELF[DPM_HOSTPROXY_CRON] = dict(
+        "pattern", "/var/log/" + DPM_HOSTPROXY_CRON + ".ncm-cron.log",
+        "compress", true,
+        "missingok", true,
+        "frequency", "monthly",
+        "create", true,
+        "ifempty", true,
+        "rotate", 2,
+    );
+    SELF;
 };

--- a/personality/se_dpm/puppet/no_pool_accounts.pan
+++ b/personality/se_dpm/puppet/no_pool_accounts.pan
@@ -1,34 +1,33 @@
 unique template personality/se_dpm/puppet/no_pool_accounts;
 
 '/software/components/accounts/users' = {
-        foreach(i;user;SELF){
-                if(is_defined(user["poolSize"]) && (user["poolSize"]>1)){
-                        user["poolSize"] = null;
-                        user["poolDigits"] = null;
-                        user["poolStart"] = null;
-                };
+    foreach(i; user; SELF){
+        if(is_defined(user["poolSize"]) && (user["poolSize"] > 1)){
+            user["poolSize"] = null;
+            user["poolDigits"] = null;
+            user["poolStart"] = null;
         };
-        SELF;
+    };
+    SELF;
 };
 
 '/software/components/mkgridmapdir/active' = false;
 
 '/system/vo' = {
-        foreach(i;vo;SELF){
-                foreach(j;auth;vo['auth']){
-                        simple_user=matches(auth['user'],'^\.(\S+)$');
-                        if(length(simple_user) > 1 ){
-                                auth['user']=simple_user[1];
-                        };
-                };
-
-                foreach(j;role;vo['voms']){
-                        simple_role=matches(role['user'],'^\.(\S+)$');
-                        if(length(simple_role) > 1 ){
-                                role['user']=simple_role[1];
-                        };
-                };
+    foreach(i; vo; SELF){
+        foreach(j; auth; vo['auth']) {
+            simple_user = matches(auth['user'], '^\.(\S+)$');
+            if(length(simple_user) > 1 ){
+                auth['user'] = simple_user[1];
+            };
         };
-        SELF;
-};
 
+        foreach(j; role; vo['voms']) {
+            simple_role=matches(role['user'], '^\.(\S+)$');
+            if(length(simple_role) > 1 ){
+                role['user'] = simple_role[1];
+            };
+        };
+    };
+    SELF;
+};

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -13,78 +13,82 @@ variable DPM_PUPPET_MODULE ?= 'sartiran-dpm';
 '/software/components/puppet/modules' ?= dict();
 
 '/software/components/puppet/modules' = {
-  if(DPM_PUPPET_MODULE != 'NONE'){
-    SELF[escape(DPM_PUPPET_MODULE)] = dict('version',DPM_PUPPET_MODULE_VERSION);
-  };
-  SELF;
+    if(DPM_PUPPET_MODULE != 'NONE') {
+        SELF[escape(DPM_PUPPET_MODULE)] = dict('version', DPM_PUPPET_MODULE_VERSION);
+    };
+    SELF;
 };
 
-variable DPMMGR_UID?=970;
+variable DPMMGR_UID ?= 970;
 
 '/software/components/puppet/hieradata' = {
-	self=dict();
-	if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]){
-		self['classes'] = 'dpm::headnode';
-	}else{
-		self['classes'] = 'dpm::disknode';
-	};	
-	self[escape('dpm::params::localdomain')] = SITE_DOMAIN;
-	self[escape('dpm::params::headnode_fqdn')] = DPM_HOSTS['dpm'][0];
+    self = dict();
+    if(FULL_HOSTNAME == DPM_HOSTS['dpm'][0]) {
+        self['classes'] = 'dpm::headnode';
+    } else {
+        self['classes'] = 'dpm::disknode';
+    };
+    self[escape('dpm::params::localdomain')] = SITE_DOMAIN;
+    self[escape('dpm::params::headnode_fqdn')] = DPM_HOSTS['dpm'][0];
 
-	self[escape('dpm::params::volist')] = VOS;
+    self[escape('dpm::params::volist')] = VOS;
 
-	if ( pkg_compare_version(DPM_PUPPET_MODULE_VERSION,'1.8.10') == PKG_VERSION_LESS ) {
-	  disk_list='';
-	  foreach(i;disk;DPM_HOSTS['disk']){
-	    if(disk_list==''){
-	      disk_list=disk;
-	    }else{
-	      disk_list=disk_list+' '+disk;
-	    };
-	  };
-        }else{
-          disk_list=DPM_HOSTS['disk'];
-	};
+    if ( pkg_compare_version(DPM_PUPPET_MODULE_VERSION, '1.8.10') == PKG_VERSION_LESS ) {
+        disk_list = '';
+        foreach(i;disk;DPM_HOSTS['disk']) {
+            if(disk_list == '') {
+                disk_list = disk;
+            } else {
+                disk_list = disk_list + ' ' + disk;
+            };
+        };
+    } else {
+        disk_list = DPM_HOSTS['disk'];
+    };
 
-	self[escape('dpm::params::disk_nodes')] = disk_list;
+    self[escape('dpm::params::disk_nodes')] = disk_list;
 
-	self[escape('dpm::params::dpmmgr_uid')] = DPMMGR_UID;
-	self[escape('dpm::params::dpmmgr_gid')] = 970;
+    self[escape('dpm::params::dpmmgr_uid')] = DPMMGR_UID;
+    self[escape('dpm::params::dpmmgr_gid')] = 970;
 
-	self[escape('dpm::params::token_password')] = 'mytokenpassword';
-	self[escape('dpm::params::xrootd_sharedkey')] = DPM_XROOTD_SHARED_KEY;
-	self[escape('dpm::params::db_pass')] = DPM_DB_PARAMS['password'];
+    self[escape('dpm::params::token_password')] = 'mytokenpassword';
+    self[escape('dpm::params::xrootd_sharedkey')] = DPM_XROOTD_SHARED_KEY;
+    self[escape('dpm::params::db_pass')] = DPM_DB_PARAMS['password'];
 
-	self[escape('dpm::params::mysql_root_pass')] = DPM_DB_PARAMS['adminpwd'];
-	self[escape('dpm::params::dpm_xrootd_fedredirs')] = XROOTD_FEDERATION_PARAMS;
+    self[escape('dpm::params::mysql_root_pass')] = DPM_DB_PARAMS['adminpwd'];
+    self[escape('dpm::params::dpm_xrootd_fedredirs')] = XROOTD_FEDERATION_PARAMS;
 
-	if(is_defined(XROOTD_REPORTING_OPTIONS)&&is_defined(XROOTD_MONITORING_OPTIONS)){
-		self[escape('dpm::params::xrd_report')] = XROOTD_REPORTING_OPTIONS;
-		self[escape('dpm::params::xrootd_monitor')] = XROOTD_MONITORING_OPTIONS;
-	};
+    if(is_defined(XROOTD_REPORTING_OPTIONS) && is_defined(XROOTD_MONITORING_OPTIONS)) {
+        self[escape('dpm::params::xrd_report')] = XROOTD_REPORTING_OPTIONS;
+        self[escape('dpm::params::xrootd_monitor')] = XROOTD_MONITORING_OPTIONS;
+    };
 
-	if(is_defined(XROOTD_SITE_NAME)){ 
-		self[escape('dpm::params::site_name')] = XROOTD_SITE_NAME;
-	};
+    if(is_defined(XROOTD_SITE_NAME)) {
+        self[escape('dpm::params::site_name')] = XROOTD_SITE_NAME;
+    };
 
-	if(is_defined(HTTPS_ENABLED) && HTTPS_ENABLED){ 
-		self[escape('dpm::params::webdav_enabled')] = true;
-		if(is_defined(DPM_MEMCACHED_ENABLED) && DPM_MEMCACHED_ENABLED){
-				self[escape('dpm::params::memcached_enabled')] = true;
-		};
-	};
+    if(is_defined(HTTPS_ENABLED) && HTTPS_ENABLED) {
+        self[escape('dpm::params::webdav_enabled')] = true;
+        if(is_defined(DPM_MEMCACHED_ENABLED) && DPM_MEMCACHED_ENABLED) {
+            self[escape('dpm::params::memcached_enabled')] = true;
+        };
+    };
 
-	if(is_defined(GRIDFTP_REDIR_ENABLED) && GRIDFTP_REDIR_ENABLED){
-		self[escape('dpm::params::gridftp_redirect')] = true;
-	};
+    if(is_defined(GRIDFTP_REDIR_ENABLED) && GRIDFTP_REDIR_ENABLED) {
+        self[escape('dpm::params::gridftp_redirect')] = true;
+    };
 
-	if(is_defined(SPACE_REPORTING_ENABLED) && SPACE_REPORTING_ENABLED){
-		self[escape('dpm::params::enable_space_reporting')] = true;
-	};
+    if(is_defined(SPACE_REPORTING_ENABLED) && SPACE_REPORTING_ENABLED) {
+        self[escape('dpm::params::enable_space_reporting')] = true;
+    };
 
-	self;
+    if(is_defined(DOME_ENABLED) && DOME_ENABLED) {
+        self[escape('dpm::params::enable_dome')] = true;
+    };
+
+    if(is_defined(DOME_FLAVOUR) && DOME_FLAVOUR) {
+        self[escape('dpm::params::enable_domeadapter')] = true;
+    };
+
+    self;
 };
-
-
-
-

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -20,6 +20,8 @@ variable DPM_PUPPET_MODULE ?= 'sartiran-dpm';
 };
 
 variable DPMMGR_UID ?= 970;
+variable DPMMGR_GID ?= 970;
+variable DMLITE_TOKEN_PASSWORD ?= error('DMLITE_TOKEN_PASSWORD must be defined');
 
 '/software/components/puppet/hieradata' = {
     self = dict();
@@ -49,17 +51,20 @@ variable DPMMGR_UID ?= 970;
     self[escape('dpm::params::disk_nodes')] = disk_list;
 
     self[escape('dpm::params::dpmmgr_uid')] = DPMMGR_UID;
-    self[escape('dpm::params::dpmmgr_gid')] = 970;
+    self[escape('dpm::params::dpmmgr_gid')] = DPMMGR_GID;
 
-    self[escape('dpm::params::token_password')] = 'mytokenpassword';
+    self[escape('dpm::params::token_password')] = DMLITE_TOKEN_PASSWORD;
     self[escape('dpm::params::xrootd_sharedkey')] = DPM_XROOTD_SHARED_KEY;
     self[escape('dpm::params::db_pass')] = DPM_DB_PARAMS['password'];
 
     self[escape('dpm::params::mysql_root_pass')] = DPM_DB_PARAMS['adminpwd'];
     self[escape('dpm::params::dpm_xrootd_fedredirs')] = XROOTD_FEDERATION_PARAMS;
 
-    if(is_defined(XROOTD_REPORTING_OPTIONS) && is_defined(XROOTD_MONITORING_OPTIONS)) {
+    if(is_defined(XROOTD_REPORTING_OPTIONS)) {
         self[escape('dpm::params::xrd_report')] = XROOTD_REPORTING_OPTIONS;
+    };
+
+    if(is_defined(XROOTD_MONITORING_OPTIONS)) {
         self[escape('dpm::params::xrootd_monitor')] = XROOTD_MONITORING_OPTIONS;
     };
 
@@ -67,27 +72,27 @@ variable DPMMGR_UID ?= 970;
         self[escape('dpm::params::site_name')] = XROOTD_SITE_NAME;
     };
 
-    if(is_defined(HTTPS_ENABLED) && HTTPS_ENABLED) {
-        self[escape('dpm::params::webdav_enabled')] = true;
-        if(is_defined(DPM_MEMCACHED_ENABLED) && DPM_MEMCACHED_ENABLED) {
-            self[escape('dpm::params::memcached_enabled')] = true;
+    if(is_boolean(HTTPS_ENABLED)) {
+        self[escape('dpm::params::webdav_enabled')] = HTTPS_ENABLED;
+        if(is_boolean(DPM_MEMCACHED_ENABLED)) {
+            self[escape('dpm::params::memcached_enabled')] = DPM_MEMCACHED_ENABLED;
         };
     };
 
-    if(is_defined(GRIDFTP_REDIR_ENABLED) && GRIDFTP_REDIR_ENABLED) {
-        self[escape('dpm::params::gridftp_redirect')] = true;
+    if(is_boolean(GRIDFTP_REDIR_ENABLED)) {
+        self[escape('dpm::params::gridftp_redirect')] = GRIDFTP_REDIR_ENABLED;
     };
 
-    if(is_defined(SPACE_REPORTING_ENABLED) && SPACE_REPORTING_ENABLED) {
-        self[escape('dpm::params::enable_space_reporting')] = true;
+    if(is_boolean(SPACE_REPORTING_ENABLED)) {
+        self[escape('dpm::params::enable_space_reporting')] = SPACE_REPORTING_ENABLED;
     };
 
-    if(is_defined(DOME_ENABLED) && DOME_ENABLED) {
-        self[escape('dpm::params::enable_dome')] = true;
+    if(is_boolean(DOME_ENABLED)) {
+        self[escape('dpm::params::enable_dome')] = DOME_ENABLED;
     };
 
-    if(is_defined(DOME_FLAVOUR) && DOME_FLAVOUR) {
-        self[escape('dpm::params::enable_domeadapter')] = true;
+    if(is_boolean(DOME_FLAVOUR)) {
+        self[escape('dpm::params::enable_domeadapter')] = DOME_FLAVOUR;
     };
 
     self;

--- a/personality/se_dpm/service.pan
+++ b/personality/se_dpm/service.pan
@@ -8,13 +8,12 @@ variable DPM_USE_PUPPET_CONFIG ?= false;
 # Ensure that the host certificates have the correct permissions.
 include 'features/security/host_certs';
 
-# Modify the loadable library path. 
+# Modify the loadable library path.
 include 'features/ldconf/config';
 
 # EDG, LCG, and Globus sysconfig files and environment variables
 include 'features/globus/sysconfig';
 include 'features/grid/env';
-
 
 # Add accepted CAs certificates
 include 'security/cas';
@@ -22,16 +21,14 @@ include 'security/cas';
 # Update the certificate revocation lists.
 include 'features/fetch-crl/config';
 
-
-# Authorization via grid mapfile. 
+# Authorization via grid mapfile.
 include 'features/mkgridmap/standard';
 include 'features/mkgridmap/lcgdm';
 
 include {
-	if(DPM_USE_PUPPET_CONFIG){
-		'personality/se_dpm/service_puppet';
-	}else{
-		'personality/se_dpm/service_quattor';
-	};
+    if(DPM_USE_PUPPET_CONFIG){
+        'personality/se_dpm/service_puppet';
+    } else {
+        'personality/se_dpm/service_quattor';
+    };
 };
-

--- a/personality/se_dpm/service_puppet.pan
+++ b/personality/se_dpm/service_puppet.pan
@@ -4,46 +4,46 @@ variable SEDPM_CONFIG_SITE ?= error("SEDPM_CONFIG_SITE should be defined");
 
 include SEDPM_CONFIG_SITE;
 
-variable SEDPM_MONITORING_ENABLED?=false;
-variable XROOT_ENABLED=true;
-variable HTTPS_ENABLED?=false;
-variable DPM_MEMCACHED_ENABLED?=false;
+variable SEDPM_MONITORING_ENABLED ?= false;
+variable XROOT_ENABLED = true;
+variable HTTPS_ENABLED ?= false;
+variable DPM_MEMCACHED_ENABLED ?= false;
 
 variable VOMS_XROOTD_EXTENSION_ENABLED = true;
 
-variable XROOTD_FEDERATION_SITE_CONFIG?=null;
+variable XROOTD_FEDERATION_SITE_CONFIG ?= null;
 
-variable SEDPM_IS_HEAD_NODE ?= if( FULL_HOSTNAME == DPM_HOSTS['dpm'][0] ) {
-                                 true;
-                               } else {
-                                 false;
-                               };
+variable SEDPM_IS_HEAD_NODE ?= (FULL_HOSTNAME == DPM_HOSTS['dpm'][0]);
 
-#Removing pool accounts
+# Removing pool accounts
 include 'personality/se_dpm/puppet/no_pool_accounts';
 
-#CMS Federation
+# CMS Federation
 include 'personality/se_dpm/puppet/federations';
 
-include if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]){XROOTD_FEDERATION_SITE_CONFIG};
+include if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]) XROOTD_FEDERATION_SITE_CONFIG;
 
-#Puppet configuration
+# Puppet configuration
 include 'features/puppet/config';
 include 'personality/se_dpm/puppet/puppetconf';
 
+# Packages
 include 'personality/se_dpm/rpms/config';
-
-'/software/packages/{mysql-server}' = if( SEDPM_IS_HEAD_NODE ){nlist()}else{null};
-
-'/software/packages/{dmlite-plugins-memcache}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
-
-'/software/packages/{memcached}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
-
-include if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]){'personality/se_dpm/puppet/bdii'};
-
-"/software/components/profile/env" = {
-  SELF["DPM_HOST"] = DPM_HOSTS['dpm'][0];
-  SELF["DPNS_HOST"] = DPM_HOSTS['dpm'][0];
-  SELF;
+'/software/packages' = {
+    if(SEDPM_IS_HEAD_NODE) {
+        pkg_repl('mysql-server');
+        if(DPM_MEMCACHED_ENABLED) {
+            pkg_repl('dmlite-plugins-memcache');
+            pkg_repl('memcached');
+        };
+    };
+    SELF;
 };
 
+include if(FULL_HOSTNAME == DPM_HOSTS['dpm'][0]) 'personality/se_dpm/puppet/bdii';
+
+"/software/components/profile/env" = {
+    SELF["DPM_HOST"] = DPM_HOSTS['dpm'][0];
+    SELF["DPNS_HOST"] = DPM_HOSTS['dpm'][0];
+    SELF;
+};


### PR DESCRIPTION
Identical to #192 but for UMD-3

- syntax and whitespace fixes
- 'gid' and 'token password' should be configurable

