### PR TITLE
Rename variable (issue with local scope naming)

### DIFF
--- a/personality/se_dpm/config_dmlite.pan
+++ b/personality/se_dpm/config_dmlite.pan
@@ -60,7 +60,7 @@ include 'components/dirperm/config';
 #       order of the configuration file must be used to ensure the appropriate load order.
 #       This configuration file is normally loaded first.
 #
-variable contents = {
+variable DMLITE_ADAPTER_CONFIG_CONTENTS ?= {
     this = '';
     # Ignore versions before 1.8.7 as dmlite was not available
     if ( DPM_VERSION == '1.8.7' ) {
@@ -85,7 +85,7 @@ variable contents = {
 include 'components/filecopy/config';
 '/software/components/filecopy/services' = {
     SELF[escape('/etc/dmlite.conf.d/adapter.conf')] = nlist(
-        'config', contents,
+        'config', DMLITE_ADAPTER_CONFIG_CONTENTS,
         'owner', DPM_USER,
         'group', DPM_GROUP,
         'perms', '0640',
@@ -105,6 +105,4 @@ include 'components/filecopy/config';
 # dmlite configuration specific to head node if needed
 # Be sure to use the same condition as the one used to select which plugin to load in adapter.conf
 include if ( SEDPM_IS_HEAD_NODE && (SEDPM_DB_TYPE == 'mysql') ) 'personality/se_dpm/server/config_dmlite';
-
-
 

--- a/personality/se_dpm/server/config_dmlite.pan
+++ b/personality/se_dpm/server/config_dmlite.pan
@@ -52,7 +52,7 @@ include if ( DMLITE_MEMCACHE_ENABLED ) 'features/memcached/config';
 #
 # /etc/dmlite.conf.d/mysql.conf
 #
-variable contents = {
+variable DMLITE_MYSQL_CONFIG_CONTENTS ?= {
     "LoadPlugin plugin_mysql_dpm /usr/" + library + "/dmlite/plugin_mysql.so\n" +
     "MySqlHost " + DPM_MYSQL_SERVER + "\n" +
     "MySqlUsername " + DPM_DB_PARAMS['user'] + "\n" +
@@ -66,7 +66,7 @@ variable contents = {
 include 'components/filecopy/config';
 '/software/components/filecopy/services' = if (is_boolean(DMLITE_ENABLED) && DMLITE_ENABLED) {
     SELF[escape('/etc/dmlite.conf.d/mysql.conf')] = nlist(
-        'config', contents,
+        'config', DMLITE_MYSQL_CONFIG_CONTENTS,
         'owner', DPM_USER,
         'group', DPM_GROUP,
         'perms', '0640',
@@ -81,7 +81,7 @@ include 'components/filecopy/config';
 #
 # /etc/dmlite.conf.d/zmemcache.conf
 #
-variable contents = {
+variable DMLITE_MEMCACHE_CONFIG_CONTENTS ?= {
   if ( DMLITE_MEMCACHE_ENABLED ) {
     "LoadPlugin plugin_memcache /usr/" + library + "/dmlite/plugin_memcache.so\n" +
     "MemcachedServer localhost:" + to_string(MEMCACHED_PORT) + "\n" +
@@ -99,7 +99,7 @@ variable contents = {
 
 '/software/components/filecopy/services' = if ( is_boolean(DMLITE_ENABLED) && DMLITE_ENABLED ) {
     SELF[escape('/etc/dmlite.conf.d/zmemcache.conf')] = nlist(
-        'config', contents,
+        'config', DMLITE_MEMCACHE_CONFIG_CONTENTS,
         'owner', 'root',
         'group', 'root',
         'perms', '0644',


### PR DESCRIPTION
Change the name of the variable to something more explicit. It permit also to avoid issues with local variable name (like 'contents').