### PR TITLE
Use correct name for HEP_OSlib RPM on EL7

### DIFF
--- a/features/wlcg/config.pan
+++ b/features/wlcg/config.pan
@@ -11,7 +11,7 @@ variable HEP_OSLIBS ?= true;
 variable HEP_OSLIBS_MAPPING ?= dict(
     'sl5', 'HEP_OSlibs_SL5',
     'sl6', 'HEP_OSlibs_SL6',
-    'el7', 'HEP_OSlibs_SL7',
+    'el7', 'HEP_OSlibs',
 );
 
 "/software/packages" = {

--- a/features/wlcg/config.pan
+++ b/features/wlcg/config.pan
@@ -20,7 +20,7 @@ variable HEP_OSLIBS_MAPPING ?= dict(
             pkg_repl(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]);
         } else {
             error(format("No HEP_OSlibs mapping defined for an OS whose major \
-                          version is %s.",OS_VERSION_PARAMS['major']));
+version is %s.", OS_VERSION_PARAMS['major']));
         };
     };
     SELF;

--- a/features/wlcg/config.pan
+++ b/features/wlcg/config.pan
@@ -15,12 +15,12 @@ variable HEP_OSLIBS_MAPPING ?= dict(
 );
 
 "/software/packages" = {
-  if ( HEP_OSLIBS ) {
-    if ( is_defined(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]) ) {
-      pkg_repl(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]);
-    } else {
-      error(format('No HEP_OSlibs mapping defined for an OS whose major version is %s.',OS_VERSION_PARAMS['major']));
+    if ( HEP_OSLIBS ) {
+        if ( is_defined(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]) ) {
+            pkg_repl(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]);
+        } else {
+            error(format('No HEP_OSlibs mapping defined for an OS whose major version is %s.', OS_VERSION_PARAMS['major']));
+        };
     };
-  };
-  SELF;
+    SELF;
 };

--- a/features/wlcg/config.pan
+++ b/features/wlcg/config.pan
@@ -19,7 +19,8 @@ variable HEP_OSLIBS_MAPPING ?= dict(
         if ( is_defined(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]) ) {
             pkg_repl(HEP_OSLIBS_MAPPING[OS_VERSION_PARAMS['major']]);
         } else {
-            error(format('No HEP_OSlibs mapping defined for an OS whose major version is %s.', OS_VERSION_PARAMS['major']));
+            error(format("No HEP_OSlibs mapping defined for an OS whose major \
+                          version is %s.",OS_VERSION_PARAMS['major']));
         };
     };
     SELF;


### PR DESCRIPTION
Set the HEP_OSlib RPM name for CentOS 7 accordingly to the RPM available in the WLCG repo