### PR TITLE
set default values for different puppet versions

### DIFF
--- a/features/puppet/config.pan
+++ b/features/puppet/config.pan
@@ -3,9 +3,8 @@ template features/puppet/config;
 include 'components/puppet/config';
 include 'components/spma/config';
 
-'/software/packages/{puppet}' ?= dict();
+'/software/packages' = pkg_repl('puppet');
 
 include 'features/puppet/defaults';
-
 
 

--- a/features/puppet/config.pan
+++ b/features/puppet/config.pan
@@ -1,9 +1,11 @@
-unique template features/puppet/config;
+template features/puppet/config;
 
-include {'components/puppet/config'};
-include {'components/spma/config'};
+include 'components/puppet/config';
+include 'components/spma/config';
 
-'/software/packages/{puppet}' ?= nlist();
+'/software/packages/{puppet}' ?= dict();
+
+include 'features/puppet/defaults';
 
 
 

--- a/features/puppet/defaults.pan
+++ b/features/puppet/defaults.pan
@@ -6,47 +6,48 @@ include 'components/puppet/config';
 
 '/software/components/puppet' = {
 
-  if(!is_defined(PUPPET_VERSION)){
-    # Default version is 3
-    version = '3.0.0'; 
-  }else{
-    if(match(PUPPET_VERSION,'^[1-9]$')){
-      # if just 1 figure, complete it to fill version number
-      version = PUPPET_VERSION + '.0.0';
+    if(!is_defined(PUPPET_VERSION)){
+        # Default version is 3
+        version = '3.0.0';
     }else{
-      version=PUPPET_VERSION;
+        if(match(PUPPET_VERSION, '^[1-9]$')){
+        # if just 1 figure, complete it to fill version number
+            version = PUPPET_VERSION + '.0.0';
+        }else{
+            version = PUPPET_VERSION;
+        };
     };
-  };
 
-  # Defaults for version > 4
-  if(pkg_compare_version(version,'4.0.0') != PKG_VERSION_LESS){
-    SELF['hieraconf_file'] = '/etc/puppetlabs/code/environments/production/hiera.yaml';
-    SELF['puppet_cmd'] = '/opt/puppetlabs/bin/puppet';
-    SELF['puppetconf_file'] = '/etc/puppetlabs/puppet/puppet.conf';
-  };
+    # Defaults for version > 4
+    if(pkg_compare_version(version,'4.0.0') != PKG_VERSION_LESS){
+        SELF['hieraconf_file'] = '/etc/puppetlabs/code/environments/production/hiera.yaml';
+        SELF['puppet_cmd'] = '/opt/puppetlabs/bin/puppet';
+        SELF['puppetconf_file'] = '/etc/puppetlabs/puppet/puppet.conf';
+    };
 
-  # Defaults for version > 5
-  if(pkg_compare_version(version,'5.0.0') != PKG_VERSION_LESS){
-    SELF['nodefiles'] = dict(escape("quattor_default.pp"), dict("contents", "lookup('classes', Array[String], 'unique').include"));
-    SELF['modulepath'] = '/etc/puppetlabs/code/environments/production/modules';
-    SELF['nodefiles_path'] = '/etc/puppetlabs/code/environments/production/manifests';
-    SELF["hieraconf"] = dict(
-      "version", 5,
-      "hierarchy", list(
-        dict(
-	  "name","quattor",
-	  "path","quattor.yaml",
-	)
-      ),
-      "defaults",dict(
-        "datadir","/etc/puppetlabs/code/environments/production/data",
-	"data_hash","yaml_data",
-      ),
-    );
-    SELF['hieradata_file'] = '/etc/puppetlabs/code/environments/production/data/quattor.yaml';        
-  };
+    # Defaults for version > 5
+    if(pkg_compare_version(version, '5.0.0') != PKG_VERSION_LESS){
+        SELF['nodefiles'] = dict(escape("quattor_default.pp"), 
+            dict("contents", "lookup('classes', Array[String], 'unique').include"));
+        SELF['modulepath'] = '/etc/puppetlabs/code/environments/production/modules';
+        SELF['nodefiles_path'] = '/etc/puppetlabs/code/environments/production/manifests';
+        SELF["hieraconf"] = dict(
+            "version", 5,
+            "hierarchy", list(
+                dict(
+	            "name", "quattor",
+	            "path", "quattor.yaml",
+	        )
+            ),
+            "defaults",dict(
+                "datadir", "/etc/puppetlabs/code/environments/production/data",
+	        "data_hash", "yaml_data",
+            ),
+        );
+        SELF['hieradata_file'] = '/etc/puppetlabs/code/environments/production/data/quattor.yaml';
+    };
   
-  SELF;
+    SELF;
 };
 
 

--- a/features/puppet/defaults.pan
+++ b/features/puppet/defaults.pan
@@ -1,0 +1,52 @@
+template features/puppet/defaults;
+
+include 'quattor/functions/package';
+
+include 'components/puppet/config';
+
+'/software/components/puppet' = {
+
+  if(!is_defined(PUPPET_VERSION)){
+    # Default version is 3
+    version = '3.0.0'; 
+  }else{
+    if(match(PUPPET_VERSION,'^[1-9]$')){
+      # if just 1 figure, complete it to fill version number
+      version = PUPPET_VERSION + '.0.0';
+    }else{
+      version=PUPPET_VERSION;
+    };
+  };
+
+  # Defaults for version > 4
+  if(pkg_compare_version(version,'4.0.0') != PKG_VERSION_LESS){
+    SELF['hieraconf_file'] = '/etc/puppetlabs/code/environments/production/hiera.yaml';
+    SELF['puppet_cmd'] = '/opt/puppetlabs/bin/puppet';
+    SELF['puppetconf_file'] = '/etc/puppetlabs/puppet/puppet.conf';
+  };
+
+  # Defaults for version > 5
+  if(pkg_compare_version(version,'5.0.0') != PKG_VERSION_LESS){
+    SELF['nodefiles'] = dict(escape("quattor_default.pp"), dict("contents", "lookup('classes', Array[String], 'unique').include"));
+    SELF['modulepath'] = '/etc/puppetlabs/code/environments/production/modules';
+    SELF['nodefiles_path'] = '/etc/puppetlabs/code/environments/production/manifests';
+    SELF["hieraconf"] = dict(
+      "version", 5,
+      "hierarchy", list(
+        dict(
+	  "name","quattor",
+	  "path","quattor.yaml",
+	)
+      ),
+      "defaults",dict(
+        "datadir","/etc/puppetlabs/code/environments/production/data",
+	"data_hash","yaml_data",
+      ),
+    );
+    SELF['hieradata_file'] = '/etc/puppetlabs/code/environments/production/data/quattor.yaml';        
+  };
+  
+  SELF;
+};
+
+

--- a/features/puppet/defaults.pan
+++ b/features/puppet/defaults.pan
@@ -19,7 +19,7 @@ include 'components/puppet/config';
     };
 
     # Defaults for version > 4
-    if(pkg_compare_version(version,'4.0.0') != PKG_VERSION_LESS){
+    if(pkg_compare_version(version, '4.0.0') != PKG_VERSION_LESS){
         SELF['hieraconf_file'] = '/etc/puppetlabs/code/environments/production/hiera.yaml';
         SELF['puppet_cmd'] = '/opt/puppetlabs/bin/puppet';
         SELF['puppetconf_file'] = '/etc/puppetlabs/puppet/puppet.conf';
@@ -27,7 +27,7 @@ include 'components/puppet/config';
 
     # Defaults for version > 5
     if(pkg_compare_version(version, '5.0.0') != PKG_VERSION_LESS){
-        SELF['nodefiles'] = dict(escape("quattor_default.pp"), 
+        SELF['nodefiles'] = dict(escape("quattor_default.pp"),
             dict("contents", "lookup('classes', Array[String], 'unique').include"));
         SELF['modulepath'] = '/etc/puppetlabs/code/environments/production/modules';
         SELF['nodefiles_path'] = '/etc/puppetlabs/code/environments/production/manifests';
@@ -35,18 +35,18 @@ include 'components/puppet/config';
             "version", 5,
             "hierarchy", list(
                 dict(
-	            "name", "quattor",
-	            "path", "quattor.yaml",
-	        )
+                    "name", "quattor",
+                    "path", "quattor.yaml",
+                )
             ),
-            "defaults",dict(
+            "defaults", dict(
                 "datadir", "/etc/puppetlabs/code/environments/production/data",
-	        "data_hash", "yaml_data",
+                "data_hash", "yaml_data",
             ),
         );
         SELF['hieradata_file'] = '/etc/puppetlabs/code/environments/production/data/quattor.yaml';
     };
-  
+
     SELF;
 };
 

--- a/features/puppet/defaults.pan
+++ b/features/puppet/defaults.pan
@@ -4,11 +4,13 @@ include 'quattor/functions/package';
 
 include 'components/puppet/config';
 
-variable PUPPET_4_INCLUDE = is_defined(PUPPET_VERSION) &&
-    (pkg_compare_version(PUPPET_VERSION, '4.0.0') != PKG_VERSION_LESS);
+variable PUPPET_FULLVERSION = {
+    version = '3.0.0';
+    if (is_defined(PUPPET_VERSION)) version = PUPPET_VERSION;
+    version = replace('^([0-9]+)$', '$1.0', version); #Pad single to double
+    version = replace('^([0-9]+\.[0-9]+)$', '$1.0', version); # Pad double to triple
+    version;
+};
 
-variable PUPPET_5_INCLUDE = is_defined(PUPPET_VERSION) &&
-    (pkg_compare_version(PUPPET_VERSION, '5.0.0') != PKG_VERSION_LESS);
-
-include if (PUPPET_4_INCLUDE) 'features/puppet/defaults_4+';
-include if (PUPPET_5_INCLUDE) 'features/puppet/defaults_5+';
+include if (pkg_compare_version(PUPPET_FULLVERSION, '4.0.0') != PKG_VERSION_LESS) 'features/puppet/defaults_4+';
+include if (pkg_compare_version(PUPPET_FULLVERSION, '5.0.0') != PKG_VERSION_LESS) 'features/puppet/defaults_5+';

--- a/features/puppet/defaults.pan
+++ b/features/puppet/defaults.pan
@@ -4,50 +4,11 @@ include 'quattor/functions/package';
 
 include 'components/puppet/config';
 
-'/software/components/puppet' = {
+variable PUPPET_4_INCLUDE = is_defined(PUPPET_VERSION) &&
+    (pkg_compare_version(PUPPET_VERSION, '4.0.0') != PKG_VERSION_LESS);
 
-    if(!is_defined(PUPPET_VERSION)){
-        # Default version is 3
-        version = '3.0.0';
-    }else{
-        if(match(PUPPET_VERSION, '^[1-9]$')){
-        # if just 1 figure, complete it to fill version number
-            version = PUPPET_VERSION + '.0.0';
-        }else{
-            version = PUPPET_VERSION;
-        };
-    };
+variable PUPPET_5_INCLUDE = is_defined(PUPPET_VERSION) &&
+    (pkg_compare_version(PUPPET_VERSION, '5.0.0') != PKG_VERSION_LESS);
 
-    # Defaults for version > 4
-    if(pkg_compare_version(version, '4.0.0') != PKG_VERSION_LESS){
-        SELF['hieraconf_file'] = '/etc/puppetlabs/code/environments/production/hiera.yaml';
-        SELF['puppet_cmd'] = '/opt/puppetlabs/bin/puppet';
-        SELF['puppetconf_file'] = '/etc/puppetlabs/puppet/puppet.conf';
-    };
-
-    # Defaults for version > 5
-    if(pkg_compare_version(version, '5.0.0') != PKG_VERSION_LESS){
-        SELF['nodefiles'] = dict(escape("quattor_default.pp"),
-            dict("contents", "lookup('classes', Array[String], 'unique').include"));
-        SELF['modulepath'] = '/etc/puppetlabs/code/environments/production/modules';
-        SELF['nodefiles_path'] = '/etc/puppetlabs/code/environments/production/manifests';
-        SELF["hieraconf"] = dict(
-            "version", 5,
-            "hierarchy", list(
-                dict(
-                    "name", "quattor",
-                    "path", "quattor.yaml",
-                )
-            ),
-            "defaults", dict(
-                "datadir", "/etc/puppetlabs/code/environments/production/data",
-                "data_hash", "yaml_data",
-            ),
-        );
-        SELF['hieradata_file'] = '/etc/puppetlabs/code/environments/production/data/quattor.yaml';
-    };
-
-    SELF;
-};
-
-
+include if (PUPPET_4_INCLUDE) 'features/puppet/defaults_4+';
+include if (PUPPET_5_INCLUDE) 'features/puppet/defaults_5+';

--- a/features/puppet/defaults_4+.pan
+++ b/features/puppet/defaults_4+.pan
@@ -1,0 +1,8 @@
+template features/puppet/defaults_4+;
+
+include 'components/puppet/config';
+
+prefix '/software/components/puppet';
+'hieraconf_file' = '/etc/puppetlabs/code/environments/production/hiera.yaml';
+'puppet_cmd' = '/opt/puppetlabs/bin/puppet';
+'puppetconf_file' = '/etc/puppetlabs/puppet/puppet.conf';

--- a/features/puppet/defaults_5+.pan
+++ b/features/puppet/defaults_5+.pan
@@ -1,0 +1,27 @@
+template features/puppet/defaults_5+;
+
+include 'components/puppet/config';
+
+prefix '/software/components/puppet';
+
+'nodefiles/{quattor_default.pp}/contents' = "lookup('classes', Array[String], 'unique').include";
+
+'modulepath' = '/etc/puppetlabs/code/environments/production/modules';
+
+'nodefiles_path' = '/etc/puppetlabs/code/environments/production/manifests';
+
+"hieraconf" = dict(
+    "version", 5,
+    "hierarchy", list(
+        dict(
+            "name", "quattor",
+            "path", "quattor.yaml",
+        )
+    ),
+    "defaults", dict(
+        "datadir", "/etc/puppetlabs/code/environments/production/data",
+        "data_hash", "yaml_data",
+    ),
+);
+
+'hieradata_file' = '/etc/puppetlabs/code/environments/production/data/quattor.yaml';


### PR DESCRIPTION
This PR goes with https://github.com/quattor/configuration-modules-core/pull/1201 the components and schema have been updated to be compliant with the most recent versions of puppet. I've just introduced a default.pan template managing the different default values corresponding to different versions.
