### PR TITLE
new version using the std dpm puppet modules

### DIFF
--- a/personality/se_dpm/puppet/no_pool_accounts.pan
+++ b/personality/se_dpm/puppet/no_pool_accounts.pan
@@ -22,10 +22,10 @@ include 'components/accounts/config';
             };
         };
         foreach(j; role; vo['voms']){
-             simple_role = matches(role['user'], '^\.(\S+)$');
-             if(length(simple_role) > 1 ){
-                 role['user'] = simple_role[1];
-             };
+            simple_role = matches(role['user'], '^\.(\S+)$');
+            if(length(simple_role) > 1 ){
+                role['user'] = simple_role[1];
+            };
         };
     };
     SELF;

--- a/personality/se_dpm/puppet/no_pool_accounts.pan
+++ b/personality/se_dpm/puppet/no_pool_accounts.pan
@@ -11,7 +11,6 @@ unique template personality/se_dpm/puppet/no_pool_accounts;
         SELF;
 };
 
-'/software/components/mkgridmapdir/active' = false;
 
 '/system/vo' = {
         foreach(i;vo;SELF){

--- a/personality/se_dpm/puppet/no_pool_accounts.pan
+++ b/personality/se_dpm/puppet/no_pool_accounts.pan
@@ -3,31 +3,30 @@ unique template personality/se_dpm/puppet/no_pool_accounts;
 include 'components/accounts/config';
 
 '/software/components/accounts/users' = {
-        foreach(i; user; SELF){
-                if(is_defined(user["poolSize"]) && (user["poolSize"]>1)){
-                        user["poolSize"] = null;
-                        user["poolDigits"] = null;
-                        user["poolStart"] = null;
-                };
+    foreach(i; user; SELF){
+        if(is_defined(user["poolSize"]) && (user["poolSize"]>1)){
+            user["poolSize"] = null;
+            user["poolDigits"] = null;
+            user["poolStart"] = null;
         };
-        SELF;
+    };
+    SELF;
 };
 
 '/system/vo' = {
-        foreach(i; vo; SELF){
-                foreach(j; auth; vo['auth']){
-                        simple_user = matches(auth['user'], '^\.(\S+)$');
-                        if(length(simple_user) > 1 ){
-                               auth['user'] = simple_user[1];
-                        };
-                };
-                foreach(j; role; vo['voms']){
-                        simple_role = matches(role['user'], '^\.(\S+)$');
-                        if(length(simple_role) > 1 ){
-                                role['user'] = simple_role[1];
-                        };
-                };
+    foreach(i; vo; SELF){
+        foreach(j; auth; vo['auth']){
+            simple_user = matches(auth['user'], '^\.(\S+)$');
+            if(length(simple_user) > 1 ){
+                auth['user'] = simple_user[1];
+            };
         };
-        SELF;
+        foreach(j; role; vo['voms']){
+             simple_role = matches(role['user'], '^\.(\S+)$');
+             if(length(simple_role) > 1 ){
+                 role['user'] = simple_role[1];
+             };
+        };
+    };
+    SELF;
 };
-

--- a/personality/se_dpm/puppet/no_pool_accounts.pan
+++ b/personality/se_dpm/puppet/no_pool_accounts.pan
@@ -1,7 +1,9 @@
 unique template personality/se_dpm/puppet/no_pool_accounts;
 
+include 'components/accounts/config';
+
 '/software/components/accounts/users' = {
-        foreach(i;user;SELF){
+        foreach(i; user; SELF){
                 if(is_defined(user["poolSize"]) && (user["poolSize"]>1)){
                         user["poolSize"] = null;
                         user["poolDigits"] = null;
@@ -11,20 +13,18 @@ unique template personality/se_dpm/puppet/no_pool_accounts;
         SELF;
 };
 
-
 '/system/vo' = {
-        foreach(i;vo;SELF){
-                foreach(j;auth;vo['auth']){
-                        simple_user=matches(auth['user'],'^\.(\S+)$');
+        foreach(i; vo; SELF){
+                foreach(j; auth; vo['auth']){
+                        simple_user = matches(auth['user'], '^\.(\S+)$');
                         if(length(simple_user) > 1 ){
-                                auth['user']=simple_user[1];
+                               auth['user'] = simple_user[1];
                         };
                 };
-
-                foreach(j;role;vo['voms']){
-                        simple_role=matches(role['user'],'^\.(\S+)$');
+                foreach(j; role; vo['voms']){
+                        simple_role = matches(role['user'], '^\.(\S+)$');
                         if(length(simple_role) > 1 ){
-                                role['user']=simple_role[1];
+                                role['user'] = simple_role[1];
                         };
                 };
         };

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -19,39 +19,39 @@ variable DOME_ENABLED ?= false;
 variable DOME_FLAVOUR ?= false;
 variable DMLITE_TOKEN_PASSWORD ?= 'mytokenpassword';
 
-variable DPM_LOG_LEVEL?=0;
-variable DPM_DISK_LOG_LEVEL?=DPM_LOG_LEVEL;
-variable DPM_HEAD_LOG_LEVEL?=DPM_LOG_LEVEL;
+variable DPM_LOG_LEVEL ?= 0;
+variable DPM_DISK_LOG_LEVEL ?= DPM_LOG_LEVEL;
+variable DPM_HEAD_LOG_LEVEL ?= DPM_LOG_LEVEL;
 
 '/software/components/puppet/modules' ?= dict();
 
 '/software/components/puppet/modules' = {
-  if(DPM_PUPPET_MODULE != 'NONE'){
-    SELF[escape(DPM_PUPPET_MODULE)] = dict('version',DPM_PUPPET_MODULE_VERSION);
-  };
-  SELF;
+    if(DPM_PUPPET_MODULE != 'NONE'){
+        SELF[escape(DPM_PUPPET_MODULE)] = dict('version', DPM_PUPPET_MODULE_VERSION);
+    };
+    SELF;
 };
 
-variable DPMMGR_UID?=970;
-variable DPMMGR_GID?=970;
+variable DPMMGR_UID ?= 970;
+variable DPMMGR_GID ?= 970;
 
 function set_yaml_boolean = {
-  
-  yes='yes';  
-  no='no';
-  
-  if(ARGC>=3 && !is_null(ARGV[2]))no=ARGV[2];
-  if(ARGC>=2 && !is_null(ARGV[1]))yes=ARGV[1];  
 
-  ret=no;
-  if(!is_null(ARGV[0]) && ARGV[0]){ret=yes};
+    yes = 'yes';  
+    no = 'no';
 
-  ret;
+    if(ARGC >= 3 && !is_null(ARGV[2]))no = ARGV[2];
+    if(ARGC >= 2 && !is_null(ARGV[1]))yes = ARGV[1];
+
+    ret = no;
+    if(!is_null(ARGV[0]) && ARGV[0]){ret = yes};
+
+    ret;
 };
 
 prefix '/software/components/puppet/hieradata';
 
-'{classes}' = set_yaml_boolean(FULL_HOSTNAME==DPM_HOSTS['dpm'][0],'dpm::headnode','dpm::disknode');
+'{classes}' = set_yaml_boolean(FULL_HOSTNAME == DPM_HOSTS['dpm'][0], 'dpm::headnode', 'dpm::disknode');
 
 '{dpm::params::localdomain}' = SITE_DOMAIN;
 '{dpm::params::headnode_fqdn}' = DPM_HOSTS['dpm'][0];
@@ -72,7 +72,7 @@ prefix '/software/components/puppet/hieradata';
 
 '{dpm::params::xrd_report}' = if(is_defined(XROOTD_REPORTING_OPTIONS)){XROOTD_REPORTING_OPTIONS}else{null};
 '{dpm::params::xrootd_monitor}' = if(is_defined(XROOTD_MONITORING_OPTIONS)){XROOTD_MONITORING_OPTIONS}else{null};
-'{dpm::params::site_name}' = if(is_defined(XROOTD_SITE_NAME)){XROOTD_SITE_NAME}else{null}; 
+'{dpm::params::site_name}' = if(is_defined(XROOTD_SITE_NAME)){XROOTD_SITE_NAME}else{null};
 
 
 '{dpm::params::webdav_enabled}' = set_yaml_boolean(HTTPS_ENABLED);
@@ -82,7 +82,7 @@ prefix '/software/components/puppet/hieradata';
 
 '{dpm::params::configure_dome}' = set_yaml_boolean(DOME_ENABLED);
 '{dpm::params::configure_domeadapter}' = set_yaml_boolean(DOME_FLAVOUR);
-	
+
 '{dpm::params::configure_bdii}' = 'no';
 '{dpm::params::configure_default_filesystem}' = 'no';
 '{dpm::params::configure_default_pool}' = 'no';

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -35,54 +35,42 @@ variable DPM_HEAD_LOG_LEVEL ?= DPM_LOG_LEVEL;
 variable DPMMGR_UID ?= 970;
 variable DPMMGR_GID ?= 970;
 
-function set_yaml_boolean = {
-
-    yes = 'yes';
-    no = 'no';
-
-    if(ARGC >= 3 && !is_null(ARGV[2]))no = ARGV[2];
-    if(ARGC >= 2 && !is_null(ARGV[1]))yes = ARGV[1];
-
-    ret = no;
-    if(!is_null(ARGV[0]) && ARGV[0]){ret = yes};
-
-    ret;
-};
-
 prefix '/software/components/puppet/hieradata';
 
-'{classes}' = set_yaml_boolean(FULL_HOSTNAME == DPM_HOSTS['dpm'][0], 'dpm::headnode', 'dpm::disknode');
+'{classes}' = if (FULL_HOSTNAME == DPM_HOSTS['dpm'][0]) 'dpm::headnode' else 'dpm::disknode';
 
+# base parameters
 '{dpm::params::localdomain}' = SITE_DOMAIN;
 '{dpm::params::headnode_fqdn}' = DPM_HOSTS['dpm'][0];
-
-'{dpm::params::volist}' = VOS;
-
 '{dpm::params::disk_nodes}' = DPM_HOSTS['disk'];
-
 '{dpm::params::dpmmgr_uid}' = DPMMGR_UID;
 '{dpm::params::dpmmgr_gid}' = DPMMGR_GID;
+'{dmlite::disk::log_level}' = DPM_DISK_LOG_LEVEL;
+'{dmlite::head::log_level}' = DPM_HEAD_LOG_LEVEL;
 
+# supported vos
+'{dpm::params::volist}' = VOS;
+
+# passwords
 '{dpm::params::token_password}' = DMLITE_TOKEN_PASSWORD;
 '{dpm::params::xrootd_sharedkey}' = DPM_XROOTD_SHARED_KEY;
 '{dpm::params::db_pass}' = DPM_DB_PARAMS['password'];
-
 '{dpm::params::mysql_root_pass}' = DPM_DB_PARAMS['adminpwd'];
+
+# xrootd conf
 '{dpm::params::dpm_xrootd_fedredirs}' = XROOTD_FEDERATION_PARAMS;
+'{dpm::params::xrd_report}' = if (is_defined(XROOTD_REPORTING_OPTIONS)) XROOTD_REPORTING_OPTIONS else null;
+'{dpm::params::xrootd_monitor}' = if (is_defined(XROOTD_MONITORING_OPTIONS)) XROOTD_MONITORING_OPTIONS else null ;
+'{dpm::params::site_name}' = if (is_defined(XROOTD_SITE_NAME)) XROOTD_SITE_NAME else null ;
 
-'{dpm::params::xrd_report}' = if(is_defined(XROOTD_REPORTING_OPTIONS)){XROOTD_REPORTING_OPTIONS}else{null};
-'{dpm::params::xrootd_monitor}' = if(is_defined(XROOTD_MONITORING_OPTIONS)){XROOTD_MONITORING_OPTIONS}else{null};
-'{dpm::params::site_name}' = if(is_defined(XROOTD_SITE_NAME)){XROOTD_SITE_NAME}else{null};
+# enable/disable options
+'{dpm::params::webdav_enabled}' = if (HTTPS_ENABLED) 'yes' else 'no';
+'{dpm::params::memcached_enabled}' = if (DPM_MEMCACHED_ENABLED) 'yes' else 'no';
+'{dpm::params::gridftp_redirect}' =  if (GRIDFTP_REDIR_ENABLED) 'yes' else 'no';
+'{dpm::params::configure_dome}' = if (DOME_ENABLED) 'yes' else 'no';
+'{dpm::params::configure_domeadapter}' = if (DOME_FLAVOUR) 'yes' else 'no';
 
-
-'{dpm::params::webdav_enabled}' = set_yaml_boolean(HTTPS_ENABLED);
-'{dpm::params::memcached_enabled}' = set_yaml_boolean(DPM_MEMCACHED_ENABLED);
-
-'{dpm::params::gridftp_redirect}' =  set_yaml_boolean(GRIDFTP_REDIR_ENABLED);
-
-'{dpm::params::configure_dome}' = set_yaml_boolean(DOME_ENABLED);
-'{dpm::params::configure_domeadapter}' = set_yaml_boolean(DOME_FLAVOUR);
-
+# disable in the puppet module some configuartions which are managed by quattor
 '{dpm::params::configure_bdii}' = 'no';
 '{dpm::params::configure_default_filesystem}' = 'no';
 '{dpm::params::configure_default_pool}' = 'no';
@@ -92,7 +80,3 @@ prefix '/software/components/puppet/hieradata';
 '{dpm::params::new_installation}' = 'no';
 '{fetchcrl::manage_carepo}' = 'no';
 '{fetchcrl::runboot}' = 'no';
-
-'{dmlite::disk::log_level}' = DPM_DISK_LOG_LEVEL;
-'{dmlite::head::log_level}' = DPM_HEAD_LOG_LEVEL;
-

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -60,8 +60,8 @@ prefix '/software/components/puppet/hieradata';
 # xrootd conf
 '{dpm::params::dpm_xrootd_fedredirs}' = XROOTD_FEDERATION_PARAMS;
 '{dpm::params::xrd_report}' = if (is_defined(XROOTD_REPORTING_OPTIONS)) XROOTD_REPORTING_OPTIONS else null;
-'{dpm::params::xrootd_monitor}' = if (is_defined(XROOTD_MONITORING_OPTIONS)) XROOTD_MONITORING_OPTIONS else null ;
-'{dpm::params::site_name}' = if (is_defined(XROOTD_SITE_NAME)) XROOTD_SITE_NAME else null ;
+'{dpm::params::xrootd_monitor}' = if (is_defined(XROOTD_MONITORING_OPTIONS)) XROOTD_MONITORING_OPTIONS else null;
+'{dpm::params::site_name}' = if (is_defined(XROOTD_SITE_NAME)) XROOTD_SITE_NAME else null;
 
 # enable/disable options
 '{dpm::params::webdav_enabled}' = if (HTTPS_ENABLED) 'yes' else 'no';

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -7,8 +7,21 @@ include 'components/puppet/config';
 include 'quattor/functions/package';
 
 #Including the needed modules
-variable DPM_PUPPET_MODULE_VERSION ?= '1.8.9';
-variable DPM_PUPPET_MODULE ?= 'sartiran-dpm';
+variable DPM_PUPPET_MODULE_VERSION ?= '0.5.8';
+variable DPM_PUPPET_MODULE ?= 'lcgdm-dpm';
+
+#Fixing some default values
+variable GRIDFTP_REDIR_ENABLED ?= false;
+variable HTTPS_ENABLED ?= false;
+variable DPM_MEMCACHED_ENABLED ?= false;
+variable GRIDFTP_REDIR_ENABLED ?= false;
+variable DOME_ENABLED ?= false;
+variable DOME_FLAVOUR ?= false;
+variable DMLITE_TOKEN_PASSWORD ?= 'mytokenpassword';
+
+variable DPM_LOG_LEVEL?=0;
+variable DPM_DISK_LOG_LEVEL?=DPM_LOG_LEVEL;
+variable DPM_HEAD_LOG_LEVEL?=DPM_LOG_LEVEL;
 
 '/software/components/puppet/modules' ?= dict();
 
@@ -20,71 +33,66 @@ variable DPM_PUPPET_MODULE ?= 'sartiran-dpm';
 };
 
 variable DPMMGR_UID?=970;
+variable DPMMGR_GID?=970;
 
-'/software/components/puppet/hieradata' = {
-	self=dict();
-	if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]){
-		self['classes'] = 'dpm::headnode';
-	}else{
-		self['classes'] = 'dpm::disknode';
-	};	
-	self[escape('dpm::params::localdomain')] = SITE_DOMAIN;
-	self[escape('dpm::params::headnode_fqdn')] = DPM_HOSTS['dpm'][0];
+function set_yaml_boolean = {
+  
+  yes='yes';  
+  no='no';
+  
+  if(ARGC>=3 && !is_null(ARGV[2]))no=ARGV[2];
+  if(ARGC>=2 && !is_null(ARGV[1]))yes=ARGV[1];  
 
-	self[escape('dpm::params::volist')] = VOS;
+  ret=no;
+  if(!is_null(ARGV[0]) && ARGV[0]){ret=yes};
 
-	if ( pkg_compare_version(DPM_PUPPET_MODULE_VERSION,'1.8.10') == PKG_VERSION_LESS ) {
-	  disk_list='';
-	  foreach(i;disk;DPM_HOSTS['disk']){
-	    if(disk_list==''){
-	      disk_list=disk;
-	    }else{
-	      disk_list=disk_list+' '+disk;
-	    };
-	  };
-        }else{
-          disk_list=DPM_HOSTS['disk'];
-	};
-
-	self[escape('dpm::params::disk_nodes')] = disk_list;
-
-	self[escape('dpm::params::dpmmgr_uid')] = DPMMGR_UID;
-	self[escape('dpm::params::dpmmgr_gid')] = 970;
-
-	self[escape('dpm::params::token_password')] = 'mytokenpassword';
-	self[escape('dpm::params::xrootd_sharedkey')] = DPM_XROOTD_SHARED_KEY;
-	self[escape('dpm::params::db_pass')] = DPM_DB_PARAMS['password'];
-
-	self[escape('dpm::params::mysql_root_pass')] = DPM_DB_PARAMS['adminpwd'];
-	self[escape('dpm::params::dpm_xrootd_fedredirs')] = XROOTD_FEDERATION_PARAMS;
-
-	if(is_defined(XROOTD_REPORTING_OPTIONS)&&is_defined(XROOTD_MONITORING_OPTIONS)){
-		self[escape('dpm::params::xrd_report')] = XROOTD_REPORTING_OPTIONS;
-		self[escape('dpm::params::xrootd_monitor')] = XROOTD_MONITORING_OPTIONS;
-	};
-
-	if(is_defined(XROOTD_SITE_NAME)){ 
-		self[escape('dpm::params::site_name')] = XROOTD_SITE_NAME;
-	};
-
-	if(is_defined(HTTPS_ENABLED) && HTTPS_ENABLED){ 
-		self[escape('dpm::params::webdav_enabled')] = true;
-		if(is_defined(DPM_MEMCACHED_ENABLED) && DPM_MEMCACHED_ENABLED){
-				self[escape('dpm::params::memcached_enabled')] = true;
-		};
-	};
-
-	if(is_defined(GRIDFTP_REDIR_ENABLED) && GRIDFTP_REDIR_ENABLED){
-		self[escape('dpm::params::gridftp_redirect')] = true;
-	};
-
-	if(is_defined(SPACE_REPORTING_ENABLED) && SPACE_REPORTING_ENABLED){
-		self[escape('dpm::params::enable_space_reporting')] = true;
-	};
-
-	self;
+  ret;
 };
 
+prefix '/software/components/puppet/hieradata';
+
+'{classes}' = set_yaml_boolean(FULL_HOSTNAME==DPM_HOSTS['dpm'][0],'dpm::headnode','dpm::disknode');
+
+'{dpm::params::localdomain}' = SITE_DOMAIN;
+'{dpm::params::headnode_fqdn}' = DPM_HOSTS['dpm'][0];
+
+'{dpm::params::volist}' = VOS;
+
+'{dpm::params::disk_nodes}' = DPM_HOSTS['disk'];
+
+'{dpm::params::dpmmgr_uid}' = DPMMGR_UID;
+'{dpm::params::dpmmgr_gid}' = DPMMGR_GID;
+
+'{dpm::params::token_password}' = DMLITE_TOKEN_PASSWORD;
+'{dpm::params::xrootd_sharedkey}' = DPM_XROOTD_SHARED_KEY;
+'{dpm::params::db_pass}' = DPM_DB_PARAMS['password'];
+
+'{dpm::params::mysql_root_pass}' = DPM_DB_PARAMS['adminpwd'];
+'{dpm::params::dpm_xrootd_fedredirs}' = XROOTD_FEDERATION_PARAMS;
+
+'{dpm::params::xrd_report}' = if(is_defined(XROOTD_REPORTING_OPTIONS)){XROOTD_REPORTING_OPTIONS}else{null};
+'{dpm::params::xrootd_monitor}' = if(is_defined(XROOTD_MONITORING_OPTIONS)){XROOTD_MONITORING_OPTIONS}else{null};
+'{dpm::params::site_name}' = if(is_defined(XROOTD_SITE_NAME)){XROOTD_SITE_NAME}else{null}; 
 
 
+'{dpm::params::webdav_enabled}' = set_yaml_boolean(HTTPS_ENABLED);
+'{dpm::params::memcached_enabled}' = set_yaml_boolean(DPM_MEMCACHED_ENABLED);
+
+'{dpm::params::gridftp_redirect}' =  set_yaml_boolean(GRIDFTP_REDIR_ENABLED);
+
+'{dpm::params::configure_dome}' = set_yaml_boolean(DOME_ENABLED);
+'{dpm::params::configure_domeadapter}' = set_yaml_boolean(DOME_FLAVOUR);
+	
+'{dpm::params::configure_bdii}' = 'no';
+'{dpm::params::configure_default_filesystem}' = 'no';
+'{dpm::params::configure_default_pool}' = 'no';
+'{dpm::params::configure_gridmap}' = 'no';
+'{dpm::params::configure_repos}' = 'no';
+'{dpm::params::configure_vos}' = 'no';
+'{dpm::params::new_installation}' = 'no';
+'{fetchcrl::manage_carepo}' = 'no';
+'{fetchcrl::runboot}' = 'no';
+
+'{dmlite::disk::log_level}' = DPM_DISK_LOG_LEVEL;
+'{dmlite::head::log_level}' = DPM_HEAD_LOG_LEVEL;
 

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -37,7 +37,7 @@ variable DPMMGR_GID ?= 970;
 
 function set_yaml_boolean = {
 
-    yes = 'yes';  
+    yes = 'yes';
     no = 'no';
 
     if(ARGC >= 3 && !is_null(ARGV[2]))no = ARGV[2];

--- a/personality/se_dpm/service_puppet.pan
+++ b/personality/se_dpm/service_puppet.pan
@@ -19,6 +19,8 @@ variable SEDPM_IS_HEAD_NODE ?= if( FULL_HOSTNAME == DPM_HOSTS['dpm'][0] ) {
                                  false;
                                };
 
+variable SEDPM_PUPPET_USE_LEGACY ?= false;
+
 #Removing pool accounts
 include 'personality/se_dpm/puppet/no_pool_accounts';
 
@@ -33,7 +35,16 @@ include 'personality/se_dpm/puppet/puppetconf';
 
 include 'personality/se_dpm/rpms/config';
 
-'/software/packages/{mysql-server}' = if( SEDPM_IS_HEAD_NODE ){nlist()}else{null};
+'/software/packages/' = {
+  if(SEDPM_IS_HEAD_NODE){
+    if( match(OS_VERSION_PARAMS['major'], '[es]l[56]')){
+      SELF[escape('mysql-server')]=dict();
+    }else{
+      SELF[escape('mariadb-server')]=dict();
+    };
+  };
+  SELF;
+};
 
 '/software/packages/{dmlite-plugins-memcache}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
 

--- a/personality/se_dpm/service_puppet.pan
+++ b/personality/se_dpm/service_puppet.pan
@@ -46,9 +46,9 @@ include 'personality/se_dpm/rpms/config';
     SELF;
 };
 
-'/software/packages/{dmlite-plugins-memcache}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
+'/software/packages/{dmlite-plugins-memcache}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){dict()}else{null};
 
-'/software/packages/{memcached}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
+'/software/packages/{memcached}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){dict()}else{null};
 
 include if(FULL_HOSTNAME == DPM_HOSTS['dpm'][0]){'personality/se_dpm/puppet/bdii'};
 

--- a/personality/se_dpm/service_puppet.pan
+++ b/personality/se_dpm/service_puppet.pan
@@ -13,11 +13,7 @@ variable VOMS_XROOTD_EXTENSION_ENABLED ?= true;
 
 variable XROOTD_FEDERATION_SITE_CONFIG ?= null;
 
-variable SEDPM_IS_HEAD_NODE ?= if( FULL_HOSTNAME == DPM_HOSTS['dpm'][0] ) {
-    true;
-}else{
-    false;
-};
+variable SEDPM_IS_HEAD_NODE ?= FULL_HOSTNAME == DPM_HOSTS['dpm'][0];
 
 variable SEDPM_PUPPET_USE_LEGACY ?= false;
 
@@ -38,9 +34,9 @@ include 'personality/se_dpm/rpms/config';
 '/software/packages' = {
     if(SEDPM_IS_HEAD_NODE){
         if( match(OS_VERSION_PARAMS['major'], '[es]l[56]')){
-            SELF[escape('mysql-server')] = dict();
+            pkg_repl('mysql-server');
         }else{
-            SELF[escape('mariadb-server')] = dict();
+            pkg_repl('mariadb-server');
         };
     };
     SELF;
@@ -54,9 +50,6 @@ include if(FULL_HOSTNAME == DPM_HOSTS['dpm'][0]){'personality/se_dpm/puppet/bdii
 
 include 'components/profile/config';
 
-"/software/components/profile/env" = {
-    SELF["DPM_HOST"] = DPM_HOSTS['dpm'][0];
-    SELF["DPNS_HOST"] = DPM_HOSTS['dpm'][0];
-    SELF;
-};
-
+prefix '/software/components/profile/env';
+'DPM_HOST' = DPM_HOSTS['dpm'][0];
+'DPNS_HOST' = DPM_HOSTS['dpm'][0];

--- a/personality/se_dpm/service_puppet.pan
+++ b/personality/se_dpm/service_puppet.pan
@@ -4,20 +4,20 @@ variable SEDPM_CONFIG_SITE ?= error("SEDPM_CONFIG_SITE should be defined");
 
 include SEDPM_CONFIG_SITE;
 
-variable SEDPM_MONITORING_ENABLED?=false;
-variable XROOT_ENABLED=true;
-variable HTTPS_ENABLED?=false;
-variable DPM_MEMCACHED_ENABLED?=false;
+variable SEDPM_MONITORING_ENABLED ?= false;
+variable XROOT_ENABLED ?= true;
+variable HTTPS_ENABLED ?= false;
+variable DPM_MEMCACHED_ENABLED ?= false;
 
-variable VOMS_XROOTD_EXTENSION_ENABLED = true;
+variable VOMS_XROOTD_EXTENSION_ENABLED ?= true;
 
-variable XROOTD_FEDERATION_SITE_CONFIG?=null;
+variable XROOTD_FEDERATION_SITE_CONFIG ?= null;
 
 variable SEDPM_IS_HEAD_NODE ?= if( FULL_HOSTNAME == DPM_HOSTS['dpm'][0] ) {
-                                 true;
-                               } else {
-                                 false;
-                               };
+    true;
+}else{
+    false;
+};
 
 variable SEDPM_PUPPET_USE_LEGACY ?= false;
 
@@ -27,7 +27,7 @@ include 'personality/se_dpm/puppet/no_pool_accounts';
 #CMS Federation
 include 'personality/se_dpm/puppet/federations';
 
-include if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]){XROOTD_FEDERATION_SITE_CONFIG};
+include if(FULL_HOSTNAME == DPM_HOSTS['dpm'][0]){XROOTD_FEDERATION_SITE_CONFIG};
 
 #Puppet configuration
 include 'features/puppet/config';
@@ -35,26 +35,28 @@ include 'personality/se_dpm/puppet/puppetconf';
 
 include 'personality/se_dpm/rpms/config';
 
-'/software/packages/' = {
-  if(SEDPM_IS_HEAD_NODE){
-    if( match(OS_VERSION_PARAMS['major'], '[es]l[56]')){
-      SELF[escape('mysql-server')]=dict();
-    }else{
-      SELF[escape('mariadb-server')]=dict();
+'/software/packages' = {
+    if(SEDPM_IS_HEAD_NODE){
+        if( match(OS_VERSION_PARAMS['major'], '[es]l[56]')){
+            SELF[escape('mysql-server')] = dict();
+        }else{
+            SELF[escape('mariadb-server')] = dict();
+        };
     };
-  };
-  SELF;
+    SELF;
 };
 
 '/software/packages/{dmlite-plugins-memcache}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
 
 '/software/packages/{memcached}' = if(SEDPM_IS_HEAD_NODE && DPM_MEMCACHED_ENABLED){nlist()}else{null};
 
-include if(FULL_HOSTNAME==DPM_HOSTS['dpm'][0]){'personality/se_dpm/puppet/bdii'};
+include if(FULL_HOSTNAME == DPM_HOSTS['dpm'][0]){'personality/se_dpm/puppet/bdii'};
+
+include 'components/profile/config';
 
 "/software/components/profile/env" = {
-  SELF["DPM_HOST"] = DPM_HOSTS['dpm'][0];
-  SELF["DPNS_HOST"] = DPM_HOSTS['dpm'][0];
-  SELF;
+    SELF["DPM_HOST"] = DPM_HOSTS['dpm'][0];
+    SELF["DPNS_HOST"] = DPM_HOSTS['dpm'][0];
+    SELF;
 };
 


### PR DESCRIPTION
Changed the templates for configuring DPM using the ncm-puppet component. Now they use the offical dmlite-dpm puppet module rather than the legacy sartiran-dpm. Also some defaults have been changed. Upgrading to this new version of templ is not transparent but as far as I know the only site using these templates, at the moment, is GRIF (which has already upgraded to the new version).
