### PR TITLE
HEP_OSlibs and ui rpm name changed

### DIFF
--- a/features/wlcg/config.pan
+++ b/features/wlcg/config.pan
@@ -11,7 +11,7 @@ variable HEP_OSLIBS ?= true;
 variable HEP_OSLIBS_MAPPING ?= dict(
     'sl5', 'HEP_OSlibs_SL5',
     'sl6', 'HEP_OSlibs_SL6',
-    'el7', 'HEP_OSlibs_SL7',
+    'el7', 'HEP_OSlibs',
 );
 
 "/software/packages" = {

--- a/personality/ui/rpms/config.pan
+++ b/personality/ui/rpms/config.pan
@@ -1,4 +1,4 @@
 unique template personality/ui/rpms/config;
 
 # EMI UI
-"/software/packages/{emi-ui}" ?= nlist();
+"/software/packages/{ui}" ?= nlist();

--- a/personality/ui/rpms/config.pan
+++ b/personality/ui/rpms/config.pan
@@ -1,4 +1,12 @@
 unique template personality/ui/rpms/config;
 
 # EMI UI
-"/software/packages/{ui}" ?= nlist();
+"/software/packages" = {
+    if (OS_VERSION_PARAMS['major'] == 'sl6') {
+        pkg_repl('emi-ui');
+    } else {
+        pkg_repl('ui');
+    };
+
+    SELF;
+};


### PR DESCRIPTION
HEP_OSlibs_SL7 is now named HEP_OSlibs in wlcg centos7 repo.

emi-ui is now named ui in the umd-4 repo (1st release https://twiki.cern.ch/twiki/bin/view/LCG/EL7UIMiddleware)
