### PR TITLE
allow use of the dpm puppet modules in the epel release

### DIFF
--- a/personality/se_dpm/puppet/forge_modules.pan
+++ b/personality/se_dpm/puppet/forge_modules.pan
@@ -1,0 +1,15 @@
+unique template personality/se_dpm/puppet/forge_modules;
+
+include 'components/puppet/config';
+
+variable DPM_PUPPET_MODULE_VERSION ?= '0.5.8';
+variable DPM_PUPPET_MODULE ?= 'lcgdm-dpm';
+
+'/software/components/puppet/modules' ?= dict();
+
+'/software/components/puppet/modules' = {
+    if(!DPM_PUPPET_RELEASE_MODULES && (DPM_PUPPET_MODULE != 'NONE')){
+        SELF[escape(DPM_PUPPET_MODULE)] = dict('version', DPM_PUPPET_MODULE_VERSION);
+    };
+    SELF;
+};

--- a/personality/se_dpm/puppet/puppetconf.pan
+++ b/personality/se_dpm/puppet/puppetconf.pan
@@ -7,8 +7,8 @@ include 'components/puppet/config';
 include 'quattor/functions/package';
 
 #Including the needed modules
-variable DPM_PUPPET_MODULE_VERSION ?= '0.5.8';
-variable DPM_PUPPET_MODULE ?= 'lcgdm-dpm';
+variable DPM_PUPPET_RELEASE_MODULES ?= false;
+variable DPM_PUPPET_FORGE_MODULES ?= !DPM_PUPPET_RELEASE_MODULES;
 
 #Fixing some default values
 variable GRIDFTP_REDIR_ENABLED ?= false;
@@ -23,17 +23,11 @@ variable DPM_LOG_LEVEL ?= 0;
 variable DPM_DISK_LOG_LEVEL ?= DPM_LOG_LEVEL;
 variable DPM_HEAD_LOG_LEVEL ?= DPM_LOG_LEVEL;
 
-'/software/components/puppet/modules' ?= dict();
-
-'/software/components/puppet/modules' = {
-    if (DPM_PUPPET_MODULE != 'NONE') {
-        SELF[escape(DPM_PUPPET_MODULE)] = dict('version', DPM_PUPPET_MODULE_VERSION);
-    };
-    SELF;
-};
-
 variable DPMMGR_UID ?= 970;
 variable DPMMGR_GID ?= 970;
+
+include if (DPM_PUPPET_FORGE_MODULES) 'personality/se_dpm/puppet/forge_modules';
+include if (DPM_PUPPET_RELEASE_MODULES) 'personality/se_dpm/puppet/release_modules';
 
 prefix '/software/components/puppet/hieradata';
 

--- a/personality/se_dpm/puppet/release_modules.pan
+++ b/personality/se_dpm/puppet/release_modules.pan
@@ -2,7 +2,7 @@ unique template personality/se_dpm/puppet/release_modules;
 
 include 'components/spma/config';
 
-'/software/packages/{dmlite-puppet-dpm}' = dict();
+'/software/packages/' = pkg_repl('dmlite-puppet-dpm');
 
 include 'components/puppet/config';
 

--- a/personality/se_dpm/puppet/release_modules.pan
+++ b/personality/se_dpm/puppet/release_modules.pan
@@ -1,0 +1,13 @@
+unique template personality/se_dpm/puppet/release_modules;
+
+include 'components/spma/config';
+
+'/software/packages/{dmlite-puppet-dpm}' = dict();
+
+include 'components/puppet/config';
+
+prefix '/software/components/puppet';
+
+'modulepath' ?= '';
+
+'modulepath' = value('/software/components/puppet/modulepath') + ':/usr/share/dmlite/puppet/modules';


### PR DESCRIPTION
This allows to use the dpm puppet modules released with epel rather than those in forge.
Tested at GRIF LLR (no issues seen so far)
