### PR TITLE
htcondorce config templates (and upgrade of condor related features)

### DIFF
--- a/features/accounting/apel/condor-accounting-fix
+++ b/features/accounting/apel/condor-accounting-fix
@@ -70,7 +70,7 @@ def condorToPBS(file,outFile):
    print "opening ",file," for reading"
 
    # Read in XML output from condor_history
-   p = subprocess.Popen(["condor_history", "-xml", "-f", file], stdout=subprocess.PIPE)
+   p = subprocess.Popen(["condor_history", "-xml", "-file", file], stdout=subprocess.PIPE)
    output, err = p.communicate()
    document = ElementTree.fromstring(output)
 
@@ -113,7 +113,10 @@ def condorToPBS(file,outFile):
          mem = "%skb" % data['ResidentSetSize_RAW']
          vmem = "%skb" % data['ImageSize_RAW']
 
-         host = (data['LastRemoteHost'].split('@'))[1]
+         try:
+            host = (data['LastRemoteHost'].split('@'))[1]
+         except:
+            host = data['LastRemoteHost']
 
          exec_host = ""
          for i in range(int(data['RequestCpus'])):

--- a/features/accounting/apel/condor-accounting-fix.new
+++ b/features/accounting/apel/condor-accounting-fix.new
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# re-write blah logs with hostname included with job id
+# convert condor history file to PBS style accounting log file for consumption by APEL parser
+#
+# Author: sartiran@llr.in2p3.fr
+#
+# Minimal modification of an original script by Andrew Lahiff
+#
+# https://github.com/alahiff/cream-for-htcondor
+#
+
+from xml.etree import ElementTree
+import sys
+import subprocess
+import glob
+import grp, pwd
+from datetime import datetime, timedelta
+import socket
+import time
+import re
+import argparse
+import os
+
+#for file in files:
+
+
+#This adds the hostname to the job ids in the blah file
+def fixBlahFile(file,outFile):
+   fi = open(file, 'r')
+   lines = fi.readlines()
+
+   #llrcream.in2p3.fr#7479916.0#1534723226
+   job_id_pattern = re.compile('(\S+)#(\d+)\.*\d*#\d+')
+
+   #outFile = '/var/apel/accounting/'+((file.split('/'))[len(file.split('/'))-1])
+   f = open(outFile,'w')
+   print 'Writing to ',outFile
+
+   LINE_EXPR = re.compile(r'\"|\"_\"')
+
+   for line in lines:
+      parts = [x.split('=',1) for x in [y for y in LINE_EXPR.split(line) if len(y) > 1]]
+      record = ''
+      for part in parts:
+         if part[0] == 'lrmsID':
+            match = job_id_pattern.match(part[1])
+            if match:
+                part[1] = "%s.%s" % (match.group(2), match.group(1))
+            else:
+                part[1] = "%s.%s" % (part[1], socket.gethostname())
+         if len(record) > 2:
+            record = record + ' '
+         record = record + '"' + part[0] + '=' + part[1] + '"'
+      record = record + "\n"
+      f.write(record)
+
+   f.close()
+   fi.close()
+
+
+usedate = datetime.now() - timedelta(days=1)
+
+parser = argparse.ArgumentParser(description='Process Condor history files for accounting purpose. Also fix blah accounting files.')
+parser.add_argument('--history-files-pattern', default='/var/lib/condor/spool/history.*',
+                   help='history logs pattern (default is /var/lib/condor/spool/history.*)')
+parser.add_argument('--parsable-dir', default='/var/lib/condor/accounting/',
+                   help='directory of the processed history logs (default is /var/lib/condor/accounting/)')
+parser.add_argument('--parsable-file-prefix', default='parsable.',
+                   help='prefix of the parsable files (default is parsable.)')
+parser.add_argument('--blah-files-pattern', default='/var/log/accounting/blahp.log-*',
+                   help='blah accounting files pattern (default is /var/log/accounting/blahp.log-*)')
+parser.add_argument('--fixed-blah-dir', default='/var/apel/accounting/',
+                   help='directory of the processed blah files (default is /var/apel/accounting/)')
+parser.add_argument('--fixed-blah-file-prefix', default='',
+                   help='prefix of fixed blah files (default is black.)')
+
+args = parser.parse_args()
+condor_history=[
+  'condor_history',
+  '-constraint', 'JobStartDate > 0',
+  '-format','%s.'+socket.getfqdn()+'|','ClusterId',
+  '-format','%s|','Owner',
+  '-format','%d|','RemoteWallClockTime',
+  '-format','%d|','RemoteUserCpu',
+  '-format','%d|','RemoteSysCpu',
+  '-format','%d|','JobStartDate',
+  '-format','%d|','EnteredCurrentStatus',
+  '-format','%d|','IfThenElse(ResidentSetSize_RAW=!=NULL,ResidentSetSize_RAW,0)',
+  '-format','%d|','IfThenElse(ImageSize_RAW=!=NULL,ImageSize_RAW,0)',
+  '-format','%d\n','RequestCpus',
+  '-file'
+]
+
+print "Processing history files"
+
+files = glob.glob(args.history_files_pattern)
+files.sort(key=lambda x: os.stat(x).st_mtime)
+for file in files:
+   outFile=args.parsable_dir+args.parsable_file_prefix+os.path.basename(file)
+   if os.path.isfile(outFile) :
+     print "Skipping file (already Processed): ",file
+   else:
+     print "Processing file: ",file
+     command_line=list(condor_history)
+     command_line.append(file)
+     p = subprocess.Popen(command_line,stdout=subprocess.PIPE)
+     output, err = p.communicate()
+     f = open(outFile,'w')
+     print 'Writing to ',outFile
+     f.write(output)
+
+print "Processing blah files"
+
+files = glob.glob(args.blah_files_pattern)
+files.sort(key=lambda x: os.stat(x).st_mtime)
+files.pop()
+for file in files:
+   outFile=args.fixed_blah_dir+args.fixed_blah_file_prefix+os.path.basename(file)
+   if os.path.isfile(outFile) :
+     print "Skipping file (already Processed): ",file
+   else:
+     print "Processing file: ",file
+     fixBlahFile(file,outFile)

--- a/features/accounting/apel/hostingcluster_fix.pan
+++ b/features/accounting/apel/hostingcluster_fix.pan
@@ -1,0 +1,85 @@
+unique template features/accounting/apel/hostingcluster_fix;
+
+include { 'features/accounting/apel/base' };
+
+#need to know the MONBOX HOST
+variable MON_HOST ?= error("Error : in order to fix the MON Box database, we need to know what is the host hosting this database...\n"
+	+ "Please define the following variable : 'MON_HOST'\n");
+
+include { 'components/filecopy/config' };
+
+#copy a script that will query the information system, and update the accounting database
+variable CONTENTS=<<EOF;
+#!/bin/bash
+
+TMP_FILE=`mktemp`
+verbose=0
+
+if [ "$1" = "--debug" ]
+then
+  MYQSL_DEBUG="-vvv"
+  verbose=1
+fi
+
+EOF
+
+# Add LDAP command with site-specific information
+variable CONTENTS = CONTENTS + "ldapsearch -x -h " + TOP_BDII_HOST + ":2170 -LLL -b mds-vo-name=" + SITE_NAME +
+                         ",mds-vo-name=local,o=grid '(objectClass=GlueCE)' GlueCEInfoHostName GlueCEHostingCluster 2>/dev/null > $TMP_FILE\n";
+
+variable CONTENTS = CONTENTS + <<EOF;
+
+[ $? -ne 0 ] && echo "Error: BDII query failed... exiting" && exit 0
+
+HOSTED_CE_LIST=`egrep '(GlueCEInfoHostName|GlueCEHostingCluster):' $TMP_FILE | awk '{ if ($1 ~ /GlueCEInfoHostName/) {printf "%s ",$2} else {print $2} }' | awk '{if ($1 != $2 ) { print $1 ";" $2 }}' |sort |uniq`
+
+for i in $HOSTED_CE_LIST; do
+    CE=${i%%;*}
+    hostingCE=${i/*;/}
+    echo "Updating SpecRecords for CE $CE hosted on cluster $hostingCE..."
+    SQL_QUERY="SET @oldCE:='$hostingCE' , @newCE:='$CE'; INSERT IGNORE INTO SpecRecords SELECT replace(S.SpecID,@oldCE ,@newCE) as SpecID,SiteName,replace(S.ClusterID,@oldCE,@newCE) as ClusterID,replace(S.SubClusterID,@oldCE,@newCE) as SubClusterID,S.SpecInt2000,S.SpecFloat2000,S.EndDate,S.EndTime,S.MeasurementDate,S.MeasurementTime FROM SpecRecords S where S.ClusterID = @oldCE ;"
+    if [ $verbose -gt 0 ]
+    then
+      echo "   SQL QUERY is : $SQL_QUERY"
+    fi
+EOF
+
+variable CONTENTS = CONTENTS + '    echo "$SQL_QUERY" | /usr/bin/mysql $MYSQL_DEBUG -u ' +
+                      APEL_DB_USER + ' --password=`cat ' + APEL_DB_PWD_CACHE  + '` -h ' + MON_HOST + " " + APEL_DB_NAME + "\n" ;
+
+variable CONTENTS = CONTENTS + <<EOF;
+done
+
+rm -f $TMP_FILE
+echo "done."
+exit 0
+EOF
+
+
+variable SCRIPT="/root/apel_hostingcluster_specrecords_fix.sh";
+"/software/components/filecopy/services" =
+  npush(escape(SCRIPT),
+        nlist("config",CONTENTS,
+              "owner","root",
+              "perms","0755"));
+
+#Create CRONTAB
+include { 'components/cron/config' };
+"/software/components/cron/entries" =
+  push(nlist(
+    "name","apel_hostingcluster_specrecords_fix",
+    "user","root",
+    "frequency", "5 0 * * *", #run right after midnight
+    "command", SCRIPT));
+
+include { 'components/altlogrotate/config' };
+"/software/components/altlogrotate/entries/apel_hostingcluster_specrecords_fix" =
+  nlist("pattern", "/var/log/apel_hostingcluster_specrecords_fix.ncm-cron.log",
+        "compress", true,
+        "missingok", true,
+        "size", '1M',
+        "create", true,
+        "ifempty", true,
+        "copytruncate", true,
+        "rotate", 10,
+       );

--- a/features/accounting/apel/parser_condor.pan
+++ b/features/accounting/apel/parser_condor.pan
@@ -1,8 +1,9 @@
 unique template features/accounting/apel/parser_condor;
 
-variable NEW_CONDOR_APEL_PARSER?=false;
+variable NEW_CONDOR_APEL_PARSER ?= false;
 
 include 'features/accounting/apel/base';
+
 # Fixme: Just to avoid full rewritting
 variable LRMS_CONFIG_DIR ?= if (exists(TORQUE_CONFIG_DIR)) {
     TORQUE_CONFIG_DIR;
@@ -11,7 +12,6 @@ variable LRMS_CONFIG_DIR ?= if (exists(TORQUE_CONFIG_DIR)) {
 };
 
 
-#
 # Allow user to customize cron startup hour
 # ATTENTION: start after 3am to be sure that blah logs are rotated
 variable APEL_PARSER_TIME_HOUR ?= '3';
@@ -31,7 +31,7 @@ include 'components/filecopy/config';
 
 '/software/components/filecopy/services/{/usr/bin/condor-accounting-fix}' = dict(
     'config', file_contents(CONDOR_ACCOUNTING_FIX),
-    'perms', '0755',                                         
+    'perms', '0755',
 );
 
 include 'components/spma/config';
@@ -42,6 +42,7 @@ include 'components/spma/config';
 # cron
 #
 include 'components/cron/config';
+
 '/software/components/cron/entries' = {
     push_if(APEL_ENABLED, dict(
         'name', APEL_PARSE_CRON_NAME,
@@ -59,21 +60,21 @@ include 'components/cron/config';
 #
 # altlogrotate
 #
-include 'components/altlogrotate/config'; 
-'/software/components/altlogrotate/entries/' = {
-    SELF[ APEL_PARSE_CRON_NAME ]= dict(
-        'pattern', '/var/log/'+APEL_PARSE_CRON_NAME+'.ncm-cron.log',
+include 'components/altlogrotate/config';
+'/software/components/altlogrotate/entries' = {
+    SELF[ APEL_PARSE_CRON_NAME ] = dict(
+        'pattern', '/var/log/' + APEL_PARSE_CRON_NAME + '.ncm-cron.log',
         'compress', true,
         'missingok', true,
         'frequency', 'weekly',
         'create', true,
         'createparams', dict(
-	    'mode', '0644',
+            'mode', '0644',
             'owner', 'root',
             'group', 'root',
-         ),
-         'ifempty', true,
-         'rotate', 2,
+        ),
+        'ifempty', true,
+        'rotate', 2,
     );
     SELF;
 };
@@ -108,11 +109,15 @@ include 'components/metaconfig/config';
             'subdirs', 'false',
         ),
         'batch', dict(
-	    'enabled', to_string((index(FULL_HOSTNAME, CE_HOSTS) >= 0)),
+            'enabled', to_string((index(FULL_HOSTNAME, CE_HOSTS) >= 0)),
             'reparse', 'false',
             'type', if(NEW_CONDOR_APEL_PARSER){'HTCondor'}else{'PBS'},
             'parallel', to_string(APEL_MULTICORE_ENABLED),
-            'dir', if(NEW_CONDOR_APEL_PARSER){LRMS_CONFIG_DIR+'/accounting'}else{LRMS_CONFIG_DIR+'/server_priv/accounting'},
+            'dir', if(NEW_CONDOR_APEL_PARSER){
+                LRMS_CONFIG_DIR + '/accounting'
+            }else{
+                LRMS_CONFIG_DIR + '/server_priv/accounting'
+            },
             'filename_prefix', if(NEW_CONDOR_APEL_PARSER){'parsable.'}else{'20'},
             'subdirs', 'false',
         ),
@@ -131,9 +136,13 @@ include 'components/dirperm/config';
 '/software/components/dirperm/paths' = if(NEW_CONDOR_APEL_PARSER){
     push(dict(
         "owner", "root:root",
-        "path", if(NEW_CONDOR_APEL_PARSER){LRMS_CONFIG_DIR+'/accounting'}else{LRMS_CONFIG_DIR+'/server_priv/accounting'},
+        "path", if(NEW_CONDOR_APEL_PARSER){
+            LRMS_CONFIG_DIR + '/accounting'
+        }else{
+            LRMS_CONFIG_DIR + '/server_priv/accounting'
+        },
         "perm", '755',
-        "type", "d"  
+        "type", "d"
     ));
 }else{
     SELF;

--- a/features/accounting/apel/parser_condor.pan
+++ b/features/accounting/apel/parser_condor.pan
@@ -1,5 +1,7 @@
 unique template features/accounting/apel/parser_condor;
 
+variable NEW_CONDOR_APEL_PARSER?=false;
+
 include 'features/accounting/apel/base';
 # Fixme: Just to avoid full rewritting
 variable LRMS_CONFIG_DIR ?= if (exists(TORQUE_CONFIG_DIR)) {
@@ -7,6 +9,7 @@ variable LRMS_CONFIG_DIR ?= if (exists(TORQUE_CONFIG_DIR)) {
 } else {
     '/var/lib/condor';
 };
+
 
 #
 # Allow user to customize cron startup hour
@@ -18,18 +21,24 @@ variable APEL_PARSE_CRON_NAME ?= 'apel-condor-log-parser';
 #
 #Script for fixing the condor accounting
 #
+variable CONDOR_ACCOUNTING_FIX = if(NEW_CONDOR_APEL_PARSER){
+    'features/accounting/apel/condor-accounting-fix.new'
+}else{
+    'features/accounting/apel/condor-accounting-fix'
+};
+
 include 'components/filecopy/config';
 
 '/software/components/filecopy/services/{/usr/bin/condor-accounting-fix}' = dict(
-    'config', file_contents('features/accounting/apel/templ/condor-accounting-fix'),
-    'perms', '0755',
+    'config', file_contents(CONDOR_ACCOUNTING_FIX),
+    'perms', '0755',                                         
 );
 
 include 'components/spma/config';
 
 '/software/packages/{python-argparse}' = dict();
 
-#
+
 # cron
 #
 include 'components/cron/config';
@@ -50,25 +59,26 @@ include 'components/cron/config';
 #
 # altlogrotate
 #
-include 'components/altlogrotate/config';
-'/software/components/altlogrotate/entries' = {
-    SELF[APEL_PARSE_CRON_NAME] = dict(
-        'pattern', '/var/log/' + APEL_PARSE_CRON_NAME + '.ncm-cron.log',
+include 'components/altlogrotate/config'; 
+'/software/components/altlogrotate/entries/' = {
+    SELF[ APEL_PARSE_CRON_NAME ]= dict(
+        'pattern', '/var/log/'+APEL_PARSE_CRON_NAME+'.ncm-cron.log',
         'compress', true,
         'missingok', true,
         'frequency', 'weekly',
         'create', true,
         'createparams', dict(
-            'mode', '0644',
+	    'mode', '0644',
             'owner', 'root',
             'group', 'root',
-        ),
-        'ifempty', true,
-        'rotate', 2,
+         ),
+         'ifempty', true,
+         'rotate', 2,
     );
-
     SELF;
 };
+
+variable APEL_BLAH_LOGS_DIR ?= '/var/apel/accounting';
 
 #
 # Configuration file
@@ -93,17 +103,17 @@ include 'components/metaconfig/config';
         ),
         'blah', dict(
             'enabled', to_string((index(FULL_HOSTNAME, CE_HOSTS) >= 0)),
-            'dir', '/var/apel/accounting',
+            'dir', APEL_BLAH_LOGS_DIR,
             'filename_prefix', 'blahp.log',
             'subdirs', 'false',
         ),
         'batch', dict(
-            'enabled', to_string((index(FULL_HOSTNAME, CE_HOSTS) >= 0)),
+	    'enabled', to_string((index(FULL_HOSTNAME, CE_HOSTS) >= 0)),
             'reparse', 'false',
-            'type', 'PBS',
+            'type', if(NEW_CONDOR_APEL_PARSER){'HTCondor'}else{'PBS'},
             'parallel', to_string(APEL_MULTICORE_ENABLED),
-            'dir', LRMS_CONFIG_DIR + '/server_priv/accounting',
-            'filename_prefix', '20',
+            'dir', if(NEW_CONDOR_APEL_PARSER){LRMS_CONFIG_DIR+'/accounting'}else{LRMS_CONFIG_DIR+'/server_priv/accounting'},
+            'filename_prefix', if(NEW_CONDOR_APEL_PARSER){'parsable.'}else{'20'},
             'subdirs', 'false',
         ),
         'logging', dict(
@@ -113,3 +123,18 @@ include 'components/metaconfig/config';
         ),
     ),
 );
+
+
+include 'components/dirperm/config';
+
+
+'/software/components/dirperm/paths' = if(NEW_CONDOR_APEL_PARSER){
+    push(dict(
+        "owner", "root:root",
+        "path", if(NEW_CONDOR_APEL_PARSER){LRMS_CONFIG_DIR+'/accounting'}else{LRMS_CONFIG_DIR+'/server_priv/accounting'},
+        "perm", '755',
+        "type", "d"  
+    ));
+}else{
+    SELF;
+};

--- a/features/accounting/apel/parser_htcondorce.pan
+++ b/features/accounting/apel/parser_htcondorce.pan
@@ -1,0 +1,80 @@
+unique template features/accounting/apel/parser_htcondorce;
+
+#
+# Base apel configuration
+#
+
+include 'features/accounting/apel/base';
+
+
+#
+# Apel configuration file
+#
+
+variable APEL_BLAH_LOGS_DIR ?= CONDOR_CONFIG['apel_output_dir'];
+variable APEL_BLAH_PREFIX ?= 'blah-';
+
+variable APEL_BATCH_LOGS_DIR ?= CONDOR_CONFIG['apel_output_dir'];
+variable APEL_BATCH_PREFIX ?= 'batch-';
+variable APEL_BATCH_TYPE = 'HTCondor';
+
+include 'components/metaconfig/config';
+
+prefix '/software/components/metaconfig/services';
+
+'{/etc/apel/parser.cfg}' = dict(
+    'mode', 0600,
+    'owner', 'condor',
+    'group', 'root',
+    'module', 'tiny',
+    'contents', dict(
+        'db', dict(
+            'hostname', MON_HOST,
+            'port', 3306,
+            'name', APEL_DB_NAME,
+            'username', APEL_DB_USER,
+            'password', APEL_DB_PWD,
+        ),
+
+        'site_info', dict(
+            'site_name', SITE_NAME,
+            'lrms_server', CE_HOST,
+        ),
+
+        'blah', dict(
+            'enabled', 'true',
+            'dir', APEL_BLAH_LOGS_DIR,
+            'filename_prefix', APEL_BLAH_PREFIX,
+            'subdirs', 'false',
+        ),
+
+        'batch', dict(
+	    'enabled', 'true',
+            'reparse', 'false',
+            'type', APEL_BATCH_TYPE,
+            'parallel', to_string(APEL_MULTICORE_ENABLED),
+            'dir', APEL_BATCH_LOGS_DIR,
+            'filename_prefix', APEL_BATCH_PREFIX,
+            'subdirs', 'false',
+        ),
+
+        'logging', dict(
+            'logfile', '/var/log/apelparser.log',
+            'level', 'INFO',
+            'console', 'true',
+        ),
+    ),
+);
+
+
+#
+# Packages
+#
+
+include 'components/spma/config';
+
+prefix '/software/packages';
+
+'{python-argparse}' = dict();
+'{mariadb}' = dict();
+

--- a/features/accounting/apel/parser_htcondorce.pan
+++ b/features/accounting/apel/parser_htcondorce.pan
@@ -49,7 +49,7 @@ prefix '/software/components/metaconfig/services';
         ),
 
         'batch', dict(
-	    'enabled', 'true',
+            'enabled', 'true',
             'reparse', 'false',
             'type', APEL_BATCH_TYPE,
             'parallel', to_string(APEL_MULTICORE_ENABLED),

--- a/features/gip/ce.pan
+++ b/features/gip/ce.pan
@@ -33,7 +33,7 @@ variable CE_OS_FAMILY ?= 'linux';
 
 @{
 desc = define VO shares to be applied to each CE
-values = percentage 
+values = percentage
 default = none
 required = no
 }
@@ -45,7 +45,7 @@ values = MB
 default = 2000
 required = no
 }
-variable CE_DEFAULT_MAX_PHYS_MEM ?= 2000*MB;
+variable CE_DEFAULT_MAX_PHYS_MEM ?= 2000 * MB;
 
 @{
 desc = define default value for job maximum virtual memory if not defined at the queue level
@@ -53,7 +53,7 @@ values = MB
 default = 20000
 required = no
 }
-variable CE_DEFAULT_MAX_VIRT_MEM ?= 20000*MB;
+variable CE_DEFAULT_MAX_VIRT_MEM ?= 20000 * MB;
 
 @{
 desc = define default value for maximum number of processors per job if not defined at the queue level
@@ -69,14 +69,14 @@ variable CREAM_CE_VERSION ?= '1.14.0';
 variable CE_HOSTS_CREAM ?= list();
 variable CE_HOSTS_LCG ?= list();
 
-variable CE_FLAVOR ?= if ( is_defined(CE_HOSTS_CREAM) && (index(FULL_HOSTNAME,CE_HOSTS_CREAM) >= 0) ) {
+variable CE_FLAVOR ?= if ( is_defined(CE_HOSTS_CREAM) && (index(FULL_HOSTNAME, CE_HOSTS_CREAM) >= 0) ) {
     'cream';
 } else {
     undef;
 };
 
 variable CE_FLAVOR = {
-    if ( is_defined(CE_FLAVOR) && !match(CE_FLAVOR,'cream') ) {
+    if ( is_defined(CE_FLAVOR) && !match(CE_FLAVOR, 'cream') ) {
         error("Invalid value for CE_FLAVOR (" + CE_FLAVOR + "). Must be 'cream'.");
     };
     SELF;
@@ -155,7 +155,7 @@ variable TOMCAT_SERVICE ?= 'tomcat6';
 # entry for each value in GIP_CE_SERVICE_PARAMS.
 variable GIP_PROVIDER_SERVICE_CONF_BASE ?= GIP_SCRIPTS_CONF_DIR + '/glite-info-service';
 variable GIP_CE_SERVICES = dict(
-    'cream',  list('creamce', 'cemon'),
+    'cream', list('creamce', 'cemon'),
 );
 variable GIP_PROVIDER_SUBSERVICE ?= dict(
     'creamce', GIP_SCRIPTS_DIR + '/glite-info-service-cream',
@@ -165,7 +165,7 @@ variable GIP_PROVIDER_SUBSERVICE ?= dict(
     'test', GIP_SCRIPTS_DIR + '/glite-info-service-test',
 );
 variable GIP_CE_SERVICE_PARAMS = dict(
-    'creamce',  dict(
+    'creamce', dict(
         'type', 'org.glite.ce.CREAM',
         'endpoint', 'https://${CREAM_HOST}:${CREAM_PORT}/ce-cream/services',
         'service', TOMCAT_SERVICE,
@@ -198,12 +198,13 @@ variable GIP_CE_SERVICE_PARAMS = dict(
         'pid_file', '$ENV{GATEKEEPER_PROCDIR}',
         'wsdl', 'nohttp://not.a.web.service/',
         'semantics', 'http://www.globus.org/toolkit/docs/2.4/gram/',
-        'service_data', '"Services=$GATEKEEPER_SERVICES\nDN=" && grid-cert-info -file /etc/grid-security/hostcert.pem -subject',
+        'service_data', '"Services=$GATEKEEPER_SERVICES\nDN=" && ' +
+            'grid-cert-info -file /etc/grid-security/hostcert.pem -subject',
         'implementationname', 'GateKeeper',
     ),
     'rtepublisher', dict(
         'type', 'org.glite.RTEPublisher',
-        'endpoint', 'gsiftp://$RTEPUBLISHER_HOST:$RTEPUBLISHER_PORT'+VO_SW_TAGS_DIR,
+        'endpoint', 'gsiftp://$RTEPUBLISHER_HOST:$RTEPUBLISHER_PORT' + VO_SW_TAGS_DIR,
         'service', 'globus-gridftp',
         'service_status_name', 'RTEPUBLISHER',
         'version', 'echo 1.0.0',
@@ -217,9 +218,9 @@ variable GIP_CE_SERVICE_PARAMS = dict(
 
 
 
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 # Add RPMs that are required by GIP on CE to update dynamic information
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 '/software/packages' = {
     pkg_repl('glite-ce-cream-utils');
     pkg_repl('glite-info-provider-service');
@@ -227,22 +228,23 @@ variable GIP_CE_SERVICE_PARAMS = dict(
         pkg_repl('lcg-info-dynamic-scheduler-pbs');
         if ( GIP_CE_USE_MAUI ) pkg_repl('lcg-info-dynamic-maui');
     };
-    if(CE_BATCH_SYS == 'condor'){ pkg_repl('dynsched-generic');};
+    if(CE_BATCH_SYS == 'condor'){ pkg_repl('dynsched-generic'); };
     SELF;
 };
 
 
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 # HTCondor: add required scripts not part of official RPMs
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 
 # Necessary only the GIP_CLUSTER_PUBLISHER_HOST (generally LRMS_SERVER_HOST)
-include  if( (CE_BATCH_SYS == 'condor') && (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) ) 'features/gip/ce-condor-plugins';
+include  if( (CE_BATCH_SYS == 'condor') && (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) )
+    'features/gip/ce-condor-plugins';
 
 
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 # Compute several variables summarizing the configuration
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 
 variable CE_DATADIR ?= 'unset';
 
@@ -290,17 +292,17 @@ variable CE_QUEUES ?= {
 variable CE_BATCH_SYS_LIST ?= {
     SELF[CE_BATCH_SYS] = CE_BATCH_SYS;
 
-    nondef_lrms=dict();
+    nondef_lrms = dict();
     if ( exists(CE_QUEUES['lrms']) && is_defined(CE_QUEUES['lrms']) ) {
-        foreach (queue;lrms;CE_QUEUES['lrms']) {
+        foreach (queue; lrms; CE_QUEUES['lrms']) {
             if ( !exists(SELF[lrms]) ) {
                 SELF[lrms] = lrms;
             };
         };
     };
-  
+
     # Update value for some specific job managers
-    foreach (jobmanager;lrms;SELF) {
+    foreach (jobmanager; lrms; SELF) {
         if ( match(lrms, 'lcgpbs|torque') ) {
             SELF[jobmanager] = 'pbs';
         } else if ( lrms == 'CONDOR' ) {
@@ -336,7 +338,7 @@ variable CE_CPU_CONFIG = {
 
     SELF;
 };
-   
+
 # Build the command to use to run the MAUI-based GIP plugins. Depending if it is run directly by the GIP or
 # used in cache mode, this wrapper will be configured as a GIP plugin or as a script to be run by some other
 # scripts (generally maui-monitoring).
@@ -356,15 +358,20 @@ variable GIP_CE_PLUGIN_COMMAND = {
         } else {
             pythonbin = 'python'
         };
-        gip_script_options = format("--max-normal-slots %d --defaults %s", CE_CPU_CONFIG['slots'], GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE);
-        SELF['ce'] = pythonbin + ' ' + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-maui --host "+LRMS_SERVER_HOST+" "+gip_script_options;
+        gip_script_options = format(
+            "--max-normal-slots %d --defaults %s",
+            CE_CPU_CONFIG['slots'],
+            GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE
+        );
+        SELF['ce'] = pythonbin + ' ' + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-maui --host " +
+            LRMS_SERVER_HOST + " " + gip_script_options;
         # FIXME: lcg-info-dynamic-scheduler doesn't allow to use a LDIF file in a non standard location...
         # Update to whatever is appropriate in cache mode when this is fixed.
         if ( GIP_CE_USE_CACHE ) {
             SELF['ce'] = SELF['ce'] + format(
-                 ' --ce-ldif %s --share-ldif %s',
-                 GIP_LDIF_DIR + '/static-file-all-CE-pbs.ldif',
-                 GIP_LDIF_DIR + '/'+GIP_CE_GLUE2_LDIF_FILES['shares']
+                ' --ce-ldif %s --share-ldif %s',
+                GIP_LDIF_DIR + '/static-file-all-CE-pbs.ldif',
+                GIP_LDIF_DIR + '/' + GIP_CE_GLUE2_LDIF_FILES['shares']
             );
         } else {
             SELF['ce'] = SELF['ce'] + format(
@@ -378,7 +385,7 @@ variable GIP_CE_PLUGIN_COMMAND = {
     # Define only if using cache mode
     if ( GIP_CE_USE_CACHE ) {
         SELF['scheduler'] = '';
-        foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
+        foreach (jobmanager; lrms; CE_BATCH_SYS_LIST) {
             # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots
             # to be computing by lcg-info-dynamic-maui rather than
             # lcg-info-dynamic-scheduler
@@ -396,20 +403,20 @@ variable GIP_CE_PLUGIN_COMMAND = {
             );
         };
     };
-  
+
     SELF;
 };
 
 
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 # Configure GIP plugins used to update dynamic information
-# ---------------------------------------------------------------------------- 
+# ----------------------------------------------------------------------------
 
 "/software/components/gip2/plugin" = {
     if ( is_defined(SELF) && !is_dict(SELF) ) {
         error('/software/components/gip2/plugin must be an dict');
     };
-  
+
     # iterate over supported batch systems
     if ( is_defined(CE_BATCH_SYS_LIST) && (length(CE_BATCH_SYS_LIST) > 0) ) {
         contents = "";
@@ -424,40 +431,41 @@ variable GIP_CE_PLUGIN_COMMAND = {
                     contents = contents + "/usr/libexec/" + GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN +
                                 " --scheduler " + CE_HOST +
                                 " --glue1-ldif /var/lib/bdii/gip/ldif/static-file-all-CE-condor.ldif" +
-                                " --glue2-ldif /var/lib/bdii/gip/ldif/ComputingShare.ldif" + 
-				" --ee-ldif /var/lib/bdii/gip/ldif/ExecutionEnvironment.ldif\n";
-                    GIP_LDIF_DIR + "/static-file-all-CE-"+lrms+".ldif "+CONDOR_HOST+"\n";
+                                " --glue2-ldif /var/lib/bdii/gip/ldif/ComputingShare.ldif" +
+                " --ee-ldif /var/lib/bdii/gip/ldif/ExecutionEnvironment.ldif\n";
+                    GIP_LDIF_DIR + "/static-file-all-CE-" + lrms + ".ldif " + CONDOR_HOST + "\n";
                 };
 
             } else if ( lrms == "lsf" ) {
-                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-lsf /usr/local/lsf/bin/ "+
+                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-lsf /usr/local/lsf/bin/ " +
                             GIP_LDIF_DIR + "/static-file-CE-" + lrms + ".ldif" + "\n";
 
             } else if ( lrms == "remotepbs" ) {
-                contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-remotepbs "+REMOTEPBS_REMOTE_HOST+
-                                                                             " "+REMOTEPBS_REMOTE_PORT+"\n";   
+                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-remotepbs " + REMOTEPBS_REMOTE_HOST +
+                                                                            " " + REMOTEPBS_REMOTE_PORT + "\n";
             } else if ( lrms == "pbs" ) {
                 # When using MAUI-based GIP plugin, GIP wrapper runs the plugin directly if not using the cache mode
                 # or just read the cache file if used in cache mode.
                 if ( GIP_CE_USE_MAUI ) {
                     if ( GIP_CE_USE_CACHE ) {
-                         # Just display the content. If the file doesn't exist, error will be detected/reported by GIP.
-                         contents = contents + 'cat ' + GIP_CE_CACHE_FILE['ce'];
+                        # Just display the content. If the file doesn't exist, error will be detected/reported by GIP.
+                        contents = contents + 'cat ' + GIP_CE_CACHE_FILE['ce'];
                     } else {
-                         contents = contents + "export PYTHONPATH=$PYTHONPATH:/usr/lib/python\n"+ GIP_CE_PLUGIN_COMMAND['ce'];
+                        contents = contents + "export PYTHONPATH=$PYTHONPATH:/usr/lib/python\n" +
+                            GIP_CE_PLUGIN_COMMAND['ce'];
                     };
                 } else {
                     if ( is_defined(LRMS_SERVER_HOST) ) {
-                        contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-pbs " + GIP_LDIF_DIR +
+                        contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-pbs " + GIP_LDIF_DIR +
                                     "/static-file-CE-" + lrms + ".ldif " + LRMS_SERVER_HOST + "\n";
                     } else {
-                        contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-pbs " + GIP_LDIF_DIR +
-                                    "/static-file-CE-" + lrms + ".ldif " + CE_HOST + "\n";  
-                   };
-               };
-           } else {
-               error("unrecognized batch system (" + lrms + "); can't configure gip CE information");
-           };
+                        contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-pbs " + GIP_LDIF_DIR +
+                                    "/static-file-CE-" + lrms + ".ldif " + CE_HOST + "\n";
+                    };
+                };
+            } else {
+                error("unrecognized batch system (" + lrms + "); can't configure gip CE information");
+            };
         };
 
         if ( length(contents) > 0 ) {
@@ -468,7 +476,7 @@ variable GIP_CE_PLUGIN_COMMAND = {
     SELF;
 };
 
-# Plugin to compute number of running jobs and ERT 
+# Plugin to compute number of running jobs and ERT
 "/software/components/gip2/plugin" = {
     # iterate over supported batch systems
     if ( is_defined(CE_BATCH_SYS_LIST) && (length(CE_BATCH_SYS_LIST) > 0) ) {
@@ -476,14 +484,15 @@ variable GIP_CE_PLUGIN_COMMAND = {
 
         foreach (jobmanager; lrms; CE_BATCH_SYS_LIST) {
             if ( lrms == "remotepbs" ) {
-                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-remotepbs "+
+                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-remotepbs " +
                             REMOTEPBS_REMOTE_HOST + " " + REMOTEPBS_REMOTE_PORT_SCHED + "\n";
             } else if ( (lrms == 'pbs') && (is_defined(GIP_CE_PLUGIN_COMMAND['scheduler'])) && GIP_CE_USE_CACHE ) {
-                # Just display the content of cache file if cache mode is used. If the file doesn't exist, error will be detected/reported by GIP.
+                # Just display the content of cache file if cache mode is used. 
+                # If the file doesn't exist, error will be detected/reported by GIP.
                 contents = contents + 'cat ' + GIP_CE_CACHE_FILE['scheduler'];
             } else {
-                # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots to be computing by lcg-info-dynamic-maui rather than
-                # lcg-info-dynamic-scheduler
+                # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots to be computing 
+                # by lcg-info-dynamic-maui rather than lcg-info-dynamic-scheduler
                 if ( (lrms == 'pbs') && GIP_CE_USE_MAUI ) {
                     remove_free_slots_cmd = '| grep -v GLUE2ComputingShareFreeSlots';
                 } else {
@@ -495,7 +504,7 @@ variable GIP_CE_PLUGIN_COMMAND = {
                     GIP_SCRIPTS_CONF_DIR,
                     lrms,
                     remove_free_slots_cmd,
-               );
+                );
             };
         };
 
@@ -529,7 +538,7 @@ variable GIP_CE_VOMAP ?= {
 
     # iterate over supported batch systems
     if ( is_defined(CE_BATCH_SYS_LIST) ) {
-        foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
+        foreach (jobmanager; lrms; CE_BATCH_SYS_LIST) {
             if ( lrms == "pbs" ) {
                 if ( GIP_CE_USE_CACHE ) {
                     static_ldif_dir = GIP_VAR_DIR;
@@ -538,43 +547,43 @@ variable GIP_CE_VOMAP ?= {
                 };
                 ldif_file = format("%s/static-file-all-CE-pbs.ldif\n", static_ldif_dir);
                 ldif_file_glue2 = format("%s/%s\n", static_ldif_dir, GIP_CE_GLUE2_LDIF_FILES['shares']);
-                contents = "[Main]\n" + "static_ldif_file: "+ ldif_file +
-                            "static_glue2_ldif_file_computingshare: "+ldif_file_glue2 +
+                contents = "[Main]\n" + "static_ldif_file: " + ldif_file +
+                            "static_glue2_ldif_file_computingshare: " + ldif_file_glue2 +
                             "vomap : \n";
-   
+
                 foreach (k; vo; GIP_CE_VOMAP) {
                     contents = contents + "  " + k + ":" + vo + "\n";
                 };
-     
-                contents = contents + 
-                            "module_search_path : ../lrms:../ett\n" + 
-                            "[LRMS]\n" + 
-                            "lrms_backend_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-pbs\n" + 
-                            "[Scheduler]\n" + 
-                            "cycle_time : 0\n" + 
-                            "vo_max_jobs_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/vomaxjobs-maui\n";
-  
+
+                contents = contents +
+                            "module_search_path : ../lrms:../ett\n" +
+                            "[LRMS]\n" +
+                            "lrms_backend_cmd: " + LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-pbs\n" +
+                            "[Scheduler]\n" +
+                            "cycle_time : 0\n" +
+                            "vo_max_jobs_cmd: " + LCG_INFO_SCRIPTS_DIR + "/vomaxjobs-maui\n";
+
             } else if ( lrms == "condor" ) {
-                contents = "[Main]\n" + 
-                             "static_ldif_file: " + GIP_LDIF_DIR + "/static-file-all-CE-"+lrms+".ldif\n" + 
-                             "vomap : \n";
-   
+                contents = "[Main]\n" +
+                            "static_ldif_file: " + GIP_LDIF_DIR + "/static-file-all-CE-" + lrms + ".ldif\n" +
+                            "vomap : \n";
+
                 foreach (k; vo; GIP_CE_VOMAP) {
                     contents = contents + "  " + k + ":" + vo + "\n";
                 };
-  
-                contents = contents + 
-                    "module_search_path : ../lrms:../ett\n" + 
-                    "[LRMS]\n" + 
-                    "lrms_backend_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-condor\n" + 
-                    "[Scheduler]\n" + 
+
+                contents = contents +
+                    "module_search_path : ../lrms:../ett\n" +
+                    "[LRMS]\n" +
+                    "lrms_backend_cmd: " + LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-condor\n" +
+                    "[Scheduler]\n" +
                     "cycle_time : 0\n";
             };
-      
-            SELF[escape(GIP_SCRIPTS_CONF_DIR+'/lcg-info-dynamic-scheduler-'+lrms+'.conf')] = contents;
+
+            SELF[escape(GIP_SCRIPTS_CONF_DIR + '/lcg-info-dynamic-scheduler-' + lrms + '.conf')] = contents;
         };
     };
-  
+
     SELF;
 };
 
@@ -604,43 +613,45 @@ variable GIP_CE_LDIF_PARAMS = {
     # can be redefined to change this behaviour).
     # Do not create if CE_FLAVOR is undefined (not a CE).
 
-    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {    
+    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
         # Build service endpoint and associated foreign key for each queue based on CE type
         queue_endpoints = list();
-        foreign_keys = list("GlueSiteUniqueID="+SITE_NAME);
+        foreign_keys = list("GlueSiteUniqueID=" + SITE_NAME);
         foreach (queue; vos; CE_QUEUES['vos']) {
             if (exists(CE_QUEUES['lrms'][queue])) {
                 jobmanager = CE_QUEUES['lrms'][queue];
                 lrms = CE_BATCH_SYS_LIST[jobmanager];
             } else {
-                jobmanager=CE_JM_TYPE;
+                jobmanager = CE_JM_TYPE;
                 lrms = jobmanager;
             };
             foreach (i; ce; CE_HOSTS_CREAM) {
 
-                ce_flavor = 'cream'; 
+                ce_flavor = 'cream';
                 if ( ce_flavor == 'cream' ) {
                     # CREAM CE doesn't know about all LCG CE job manager variants...
                     jobmanager = lrms;
                     queue_endpoints[length(queue_endpoints)] = ce + ":" + to_string(CE_PORT[ce_flavor]) +
-                                                                "/cream-" + jobmanager + "-" + queue;
-                    foreign_keys[length(foreign_keys)] = "GlueCEUniqueID=" +ce + ":" + 
-                                                          to_string(CE_PORT[ce_flavor]) + "/cream-" +
-                                                          jobmanager + "-" + queue;
+                        "/cream-" + jobmanager + "-" + queue;
+                    foreign_keys[length(foreign_keys)] = "GlueCEUniqueID=" + ce + ":" +
+                        to_string(CE_PORT[ce_flavor]) + "/cream-" + jobmanager + "-" + queue;
                 } else {
                     queue_endpoints[length(queue_endpoints)] = ce + ":" + to_string(CE_PORT[ce_flavor]) +
-                                                                "/jobmanager-" + jobmanager + "-" + queue;
+                        "/jobmanager-" + jobmanager + "-" + queue;
                     foreign_keys[length(foreign_keys)] = "GlueCEUniqueID=" + ce + ":" +
-                                                          to_string(CE_PORT[ce_flavor]) + "/jobmanager-" +
-                                                          jobmanager + "-" + queue;
+                        to_string(CE_PORT[ce_flavor]) + "/jobmanager-" +
+                        jobmanager + "-" + queue;
                 };
             };
         };
-  
+
         cluster_entries_g1 = dict();
-        cluster_entries_g1[escape('dn: GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST + ',Mds-Vo-name=resource,o=grid')] = 
-        dict(
-            "objectClass", list('GlueClusterTop', 'GlueCluster', 'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
+        cluster_entries_g1[escape(
+            'dn: GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST + ',Mds-Vo-name=resource,o=grid'
+        )] = dict(
+            "objectClass", list(
+                'GlueClusterTop', 'GlueCluster', 'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'
+            ),
             "GlueClusterName", list(GIP_CLUSTER_PUBLISHER_HOST),
             "GlueForeignKey", foreign_keys,
             "GlueClusterService", queue_endpoints,
@@ -648,21 +659,25 @@ variable GIP_CE_LDIF_PARAMS = {
             "GlueSchemaVersionMajor", list("1"),
             "GlueSchemaVersionMinor", list("3"),
         );
-  
+
         # For GlueHostArchitecturePlatformType, assume the same type as CE until we support several subclusters
         # per cluster.
         average_core_num = to_double(CE_CPU_CONFIG['slots']) / CE_CPU_CONFIG['cpus'];
         hepspec06 = 4 * to_double(CE_SI00) / 1000;
 
-        cluster_entries_g1[escape('dn: GlueSubClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST +
-                                   ', GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST +
-                                   ',Mds-Vo-name=resource,o=grid')] = 
-        dict(
-            'objectClass', list('GlueClusterTop', 'GlueSubCluster', 'GlueHostApplicationSoftware', 'GlueHostArchitecture',
-                                 'GlueHostBenchmark', 'GlueHostMainMemory', 'GlueHostOperatingSystem', 'GlueHostProcessor',
-                                 'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
+        cluster_entries_g1[escape(
+            'dn: GlueSubClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST +
+            ', GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST +
+            ',Mds-Vo-name=resource,o=grid'
+        )] = dict(
+
+            'objectClass', list(
+                'GlueClusterTop', 'GlueSubCluster', 'GlueHostApplicationSoftware', 'GlueHostArchitecture',
+                'GlueHostBenchmark', 'GlueHostMainMemory', 'GlueHostOperatingSystem', 'GlueHostProcessor',
+                'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'
+            ),
             'GlueSubClusterUniqueID', list(GIP_CLUSTER_PUBLISHER_HOST),
-            'GlueChunkKey', list('GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST),
+            'GlueChunkKey', list('GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST),
             'GlueHostArchitectureSMPSize', list(CE_SMPSIZE),
             'GlueHostArchitecturePlatformType', list(CE_WN_ARCH),
             'GlueHostBenchmarkSF00', list(CE_SF00),
@@ -676,8 +691,8 @@ variable GIP_CE_LDIF_PARAMS = {
             'GlueHostOperatingSystemVersion', list(CE_OS_VERSION),
             'GlueHostProcessorClockSpeed', list(CE_CPU_SPEED),
             'GlueHostProcessorModel', list(CE_CPU_MODEL),
-            'GlueHostProcessorOtherDescription', list('Cores='+ to_string(average_core_num) +
-                                                      ',Benchmark=' + to_string(hepspec06) + '-HEP-SPEC06'),
+            'GlueHostProcessorOtherDescription', list('Cores=' + to_string(average_core_num) +
+                ',Benchmark=' + to_string(hepspec06) + '-HEP-SPEC06'),
             'GlueHostProcessorVendor', list(CE_CPU_VENDOR),
             'GlueSubClusterName', list(FULL_HOSTNAME),
             'GlueSubClusterPhysicalCPUs', list(to_string(CE_CPU_CONFIG['cpus'])),
@@ -693,7 +708,7 @@ variable GIP_CE_LDIF_PARAMS = {
         SELF["glue1"]["lcg-info-static-cluster.conf"]['ldifFile'] = "static-file-Cluster.ldif";
         SELF["glue1"]["lcg-info-static-cluster.conf"]['entries'] = cluster_entries_g1;
     };
-  
+
 
     # Glue CE static information.
     # When using GIP in cache mode and the current node is the LRMS
@@ -708,12 +723,12 @@ variable GIP_CE_LDIF_PARAMS = {
         host_entries_g1 = dict();
         all_ce_entries_g1 = dict();
         share_entries_g2 = dict();
-    
+
         foreach (queue; vos; CE_QUEUES['vos']) {
             if (exists(CE_QUEUES['lrms'][queue])) {
                 jobmanager = CE_QUEUES['lrms'][queue];
             } else {
-                jobmanager=CE_BATCH_SYS;
+                jobmanager = CE_BATCH_SYS;
             };
             lrms = CE_BATCH_SYS_LIST[jobmanager];
             if ( !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
@@ -722,9 +737,9 @@ variable GIP_CE_LDIF_PARAMS = {
             # GIP_CE_USE_CACHE is true).
             #if ( GIP_CE_USE_CACHE && !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
             if ( !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
-   
+
             # FIXME: cache mode should not be specific to Torque/MAUI...
-            # FIXME: cluster mode (distinct CEs and LRMS master) validation with LRMS other than Torque/MAUI 
+            # FIXME: cluster mode (distinct CEs and LRMS master) validation with LRMS other than Torque/MAUI
             if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) { ##Changed LRMS_SERVER_HOST->GIP_CLUSTER_PUBLISHER_HOST
                 ce_list = merge(CE_HOSTS_LCG, CE_HOSTS_CREAM);
                 # Create only if necessary to avoid creating a useless emtpy file
@@ -737,9 +752,9 @@ variable GIP_CE_LDIF_PARAMS = {
             } else {
                 ce_list = list(FULL_HOSTNAME);
             };
-      
-            foreach (i;ce;ce_list) {
-                if ( index(ce,CE_HOSTS_LCG) >= 0 ) {
+
+            foreach (i; ce; ce_list) {
+                if ( index(ce, CE_HOSTS_LCG) >= 0 ) {
                     ce_flavor = 'lcg';
                     unique_id = ce + ':' + to_string(CE_PORT[ce_flavor]) + '/jobmanager-' + jobmanager + '-' + queue;
                 } else {
@@ -748,24 +763,25 @@ variable GIP_CE_LDIF_PARAMS = {
                     jobmanager = lrms;
                     unique_id = ce + ':' + to_string(CE_PORT[ce_flavor]) + '/cream-' + jobmanager + '-' + queue;
                 };
-        
+
                 access = list();
                 contact = list();
-  
+
                 # Try to set up initial GlueCEStateStatus according to defined
                 # queue state, else assume default. Assume the same state on all CEs.
                 # Will be updated by GIP to reflect the exact status.
+
                 if ( exists('/software/components/pbsserver/queue/queuelist') ) {
                     queuelist = value('/software/components/pbsserver/queue/queuelist');
                     if ( is_defined(queuelist[queue]['attlist']['enabled']) &&
-                         is_defined(queuelist[queue]['attlist']['started']) ) {
+                        is_defined(queuelist[queue]['attlist']['started']) ) {
                         if ( queuelist[queue]['attlist']['enabled'] && queuelist[queue]['attlist']['started'] ) {
                             queue_status = 'Production';
-                        } else if ( queuelist[queue]['attlist']['enabled'] && !queuelist[queue]['attlist']['started'] ) {
+                        }else if( queuelist[queue]['attlist']['enabled'] && !queuelist[queue]['attlist']['started']){
                             queue_status = 'Queueing';
-                        } else if ( queuelist[queue]['attlist']['started'] && !queuelist[queue]['attlist']['enabled'] ) {
+                        }else if( queuelist[queue]['attlist']['started'] && !queuelist[queue]['attlist']['enabled']){
                             queue_status = 'Draining';
-                        } else {
+                        }else{
                             queue_status = 'Closed';
                         };
                     } else {
@@ -774,40 +790,40 @@ variable GIP_CE_LDIF_PARAMS = {
                 } else {
                     queue_status = CE_STATUS;
                 };
-  
+
                 entries_g1 = dict();
                 entries_g2 = dict();
                 foreach (k; vo; vos) {
                     vo_name = VO_INFO[vo]['name'];
                     rule = "VO:" + vo_name;
                     access[length(access)] = rule;
-  
+
                     if ( is_defined(CE_DEFAULT_SE) ) {
                         gluese_info_default_se = dict('GlueCEInfoDefaultSE', list(CE_DEFAULT_SE));
                     } else {
                         gluese_info_default_se = dict();
                     };
-          
+
                     if ( is_defined(CE_VO_DEFAULT_SE[vo]) ) {
                         gluese_info_default_se = dict('GlueCEInfoDefaultSE', list(CE_VO_DEFAULT_SE[vo]));
                     };
-  
+
                     if ( is_defined(VO_INFO[vo]['swarea']['name']) ) {
                         sw_area = dict('GlueCEInfoApplicationDir', list(VO_INFO[vo]['swarea']['name']));
                     } else {
                         sw_area = dict();
                     };
-  
+
                     #FIXME: use home directory if in a shared area
                     shared_data_dir = dict('GlueCEInfoDataDir', list(CE_DATADIR));
-          
+
                     # GLUE1 GlueVOView entry (LDIF, 1/VO/CE)
                     entries_g1[escape('dn: GlueVOViewLocalID=' + vo_name + ',GlueCEUniqueID=' +
                                 unique_id + ',Mds-Vo-name=resource,o=grid')] = merge(
                         dict(
                             'objectClass', list('GlueCETop', 'GlueVOView', 'GlueCEInfo', 'GlueCEState',
-                                                 'GlueCEAccessControlBase', 'GlueCEPolicy',
-                                                 'GlueKey', 'GlueSchemaVersion'),
+                                                'GlueCEAccessControlBase', 'GlueCEPolicy',
+                                                'GlueKey', 'GlueSchemaVersion'),
                             'GlueVOViewLocalID', list(vo_name),
                             'GlueSchemaVersionMajor', list('1'),
                             'GlueSchemaVersionMinor', list('3'),
@@ -818,20 +834,20 @@ variable GIP_CE_LDIF_PARAMS = {
                             'GlueCEStateFreeJobSlots', list('0'),
                             'GlueCEStateEstimatedResponseTime', list('2146660842'),
                             'GlueCEStateWorstResponseTime', list('2146660842'),
-                            'GlueChunkKey', list("GlueCEUniqueID="+unique_id),
+                            'GlueChunkKey', list("GlueCEUniqueID=" + unique_id),
                         ),
                         gluese_info_default_se,
                         sw_area,
                         shared_data_dir,
                     );
                 };
-    
+
                 # GLUE1 GlueCE entry (LDIF)
                 entries_g1[escape('dn: GlueCEUniqueID=' + unique_id + ',Mds-Vo-name=resource,o=grid')] = merge(
                     dict(
                         'objectClass', list('GlueCETop', 'GlueCE', 'GlueCEAccessControlBase',
-                                             'GlueCEInfo', 'GlueCEPolicy', 'GlueCEState',
-                                             'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
+                                            'GlueCEInfo', 'GlueCEPolicy', 'GlueCEState',
+                                            'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
                         'GlueCEImplementationName', list(GLUE_CE_IMPLEMENTATION[ce_flavor]),
                         'GlueCEImplementationVersion', list(CREAM_CE_VERSION),
                         'GlueCEHostingCluster', list(GIP_CLUSTER_PUBLISHER_HOST),
@@ -839,7 +855,7 @@ variable GIP_CE_LDIF_PARAMS = {
                         'GlueCEUniqueID', list(unique_id),
                         'GlueCEInfoGatekeeperPort', list(to_string(CE_PORT[ce_flavor])),
                         # This is a hack to fix a problem affecting WMS/NagiosBox that don't like a InfoHostName
-                        # that doesn't match a CE name... InfoHostName should be FULL_HOSTNAME normally. 
+                        # that doesn't match a CE name... InfoHostName should be FULL_HOSTNAME normally.
                         'GlueCEInfoHostName', list(ce),
                         'GlueCEInfoLRMSType', list(lrms),
                         'GlueCEInfoLRMSVersion', list('not defined'),
@@ -863,7 +879,7 @@ variable GIP_CE_LDIF_PARAMS = {
                         'GlueCEPolicyPriority', list('1'),
                         'GlueCEPolicyAssignedJobSlots', list('0'),
                         'GlueCECapability', CE_CAPABILITIES,
-                        'GlueForeignKey', list('GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST),
+                        'GlueForeignKey', list('GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST),
                         'GlueInformationServiceURL', list(RESOURCE_INFORMATION_URL),
                         'GlueCEAccessControlBaseRule', access,
                         'GlueCEPolicyMaxObtainableCPUTime', list('0'),
@@ -881,7 +897,7 @@ variable GIP_CE_LDIF_PARAMS = {
                 if ( ce == FULL_HOSTNAME ) {
                     host_entries_g1[lrms] = merge(host_entries_g1[lrms], entries_g1);
                 };
-        
+
                 # Also add to GLUE1 LDIF file used when cache mode is enabled (several entries in ce_list)
                 if ( is_dict(all_ce_entries_g1[lrms]) ) {
                     all_ce_entries_g1[lrms] = merge(all_ce_entries_g1[lrms], entries_g1);
@@ -890,13 +906,13 @@ variable GIP_CE_LDIF_PARAMS = {
                 foreach (k; vo; vos) {
                     vo_name = VO_INFO[vo]['name'];
                     # GLUE2 entry (LDIF generator config entry).
-	            if(!is_defined(GLUE2_SHARES_BY_CE)||!GLUE2_SHARES_BY_CE){
+                    if(!is_defined(GLUE2_SHARES_BY_CE)||!GLUE2_SHARES_BY_CE){
                         # GLUE2 shares are independent of CEs: add only once.
                         share_name =  replace('\.', '-', format('%s_%s', queue, vo_name));
                     }else{
-	                # GLUE2 shares are different by CEs as queues depends on the CEs
-	                share_name =  replace('\.', '-', format('%s_%s_%s', ce, queue, vo_name));
-	            };
+                        # GLUE2 shares are different by CEs as queues depends on the CEs
+                        share_name =  replace('\.', '-', format('%s_%s_%s', ce, queue, vo_name));
+                    };
                     if ( !is_defined(share_entries_g2[lrms][share_name]) ) {
                         glue2_var_prefix = format('SHARE_%s_', to_uppercase(share_name));
                         entries_g2[share_name] = dict(
@@ -912,47 +928,49 @@ variable GIP_CE_LDIF_PARAMS = {
 
                 # GLUE2 : add entries if on the LRMS master node
                 if ( is_dict(share_entries_g2[lrms]) ) {
-                    share_entries_g2[lrms] = merge(share_entries_g2[lrms],entries_g2);
+                    share_entries_g2[lrms] = merge(share_entries_g2[lrms], entries_g2);
                 };
 
-               
+
             };           # end of iteration over CEs
-      
+
         };             # end of iteration over queues
-                 
+
         # Create LDIF configuration entries describing CE queues (GlueCE and GlueVOView).
-        # FIXME: restore original behaviour when lcg-info-dynamic-scheduler is fixed (https://ggus.eu/index.php?mode=ticket_info&ticket_id=110336).
+        # FIXME: restore original behaviour when lcg-info-dynamic-scheduler is fixed 
+        # (https://ggus.eu/index.php?mode=ticket_info&ticket_id=110336).
         #        See other related section at the beginning of this block.
         # Due to a problem in lcg-info-dynamic-scheduler not allowing anymore to redefine
         # the static file location, everything is published on the GIP_CLUSTER_PUBLISHER_HOST as
         # there is no point to publish the same information twice on different hosts.
-#    if ( index(FULL_HOSTNAME,CE_HOSTS) >= 0 ) {
-#      foreach (lrms;ce_entries;host_entries_g1) {
-#        conf_file_g1 = "lcg-info-static-ce-"+lrms+".conf";
-#        SELF['glue1'][conf_file_g1]['ldifFile'] = "static-file-CE-"+lrms+".ldif";
+#    if ( index(FULL_HOSTNAME, CE_HOSTS) >= 0 ) {
+#      foreach (lrms; ce_entries; host_entries_g1) {
+#        conf_file_g1 = "lcg-info-static-ce-" + lrms + ".conf";
+#        SELF['glue1'][conf_file_g1]['ldifFile'] = "static-file-CE-" + lrms + ".ldif";
 #        if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) ) SELF['glue1'][conf_file_g1]['entries'] = dict();
-#        SELF['glue1'][conf_file_g1]['entries'] = merge(SELF['glue1'][conf_file_g1]['entries'],ce_entries);
+#        SELF['glue1'][conf_file_g1]['entries'] = merge(SELF['glue1'][conf_file_g1]['entries'], ce_entries);
 #      };
 #    } else {
         if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
             foreach (lrms; ce_entries; all_ce_entries_g1) {
                 conf_file_g1 = "lcg-info-static-all-CE-" + lrms + ".conf";
-                # Use standard location for LDIF file until the lcg-info-dynamic-scheduler issue is fixed and 
+                # Use standard location for LDIF file until the lcg-info-dynamic-scheduler issue is fixed and
                 # original behaviour can be restored.
-                #SELF['glue1'][conf_file_g1]['ldifFile'] = GIP_VAR_DIR + "/static-file-all-CE-"+lrms+".ldif";
+                #SELF['glue1'][conf_file_g1]['ldifFile'] = GIP_VAR_DIR + "/static-file-all-CE-" + lrms + ".ldif";
                 SELF['glue1'][conf_file_g1]['ldifFile'] = "static-file-all-CE-" + lrms + ".ldif";
-                if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) ) SELF['glue1'][conf_file_g1]['entries'] = dict();
+                if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) )
+                    SELF['glue1'][conf_file_g1]['entries'] = dict();
                 SELF['glue1'][conf_file_g1]['entries'] = merge(SELF['glue1'][conf_file_g1]['entries'], ce_entries);
             };
         };
-        foreach (lrms;share_entries;share_entries_g2) {
+        foreach (lrms; share_entries; share_entries_g2) {
             conf_file_g2 = "glite-ce-glue2.conf";
             if ( !is_defined(SELF['glue2']['shares']) ) SELF['glue2']['shares'] = dict();
             SELF['glue2']['shares'] = merge(SELF['glue2']['shares'], share_entries);
         };
     };
-     
-      
+
+
     # Glue CE-SE binding static information.
     # Do not create if CE_FLAVOR is undefined (not a CE).
 
@@ -960,25 +978,25 @@ variable GIP_CE_LDIF_PARAMS = {
         # iterate over all defined queues (there is one GlueCE object per queue)
         if ( is_defined(CE_QUEUES['vos']) ) {
             close_se_entries_g1 = dict();
-      
-            foreach (queue;vos;CE_QUEUES['vos']) {
+
+            foreach (queue; vos; CE_QUEUES['vos']) {
                 if (exists(CE_QUEUES['lrms'][queue])) {
                     jobmanager = CE_QUEUES['lrms'][queue];
                 } else {
                     jobmanager = CE_BATCH_SYS;
                 };
                 lrms = CE_BATCH_SYS_LIST[jobmanager];
-    
+
                 if ( CE_FLAVOR == 'cream' ) {
                     # On CREAM CE, there is no distinction between lcgpbs and pbs. Reset jobmanager to lrms.
                     jobmanager = lrms;
                     unique_id = FULL_HOSTNAME + ':' + to_string(CE_PORT[CE_FLAVOR]) +
-                                 '/cream-' + jobmanager + '-' + queue;
+                        '/cream-' + jobmanager + '-' + queue;
                 } else {
                     unique_id = FULL_HOSTNAME + ':' + to_string(CE_PORT[CE_FLAVOR]) +
-                                 '/jobmanager-' + jobmanager + '-' + queue;
+                        '/jobmanager-' + jobmanager + '-' + queue;
                 };
-          
+
                 # Compute close SE list for the current queue by doing union of close SE
                 # for all VO authorized to access the queue.
                 # CE_VO_CLOSE_SE contains one entry per VO supported on the CE.
@@ -997,7 +1015,7 @@ variable GIP_CE_LDIF_PARAMS = {
                         queue_close_se_list[length(queue_close_se_list)] = se;
                     };
                 };
-    
+
                 # Define list of SEs usable by this queue
                 if ( length(queue_close_se_list) > 0 ) {
                     close_se_entries_g1[escape('dn: GlueCESEBindGroupCEUniqueID=' + unique_id +
@@ -1008,16 +1026,16 @@ variable GIP_CE_LDIF_PARAMS = {
                         'GlueSchemaVersionMinor', list('3'),
                     );
                 };
-    
+
                 # Define a GlueCESEBindSEUniqueID per SE usable from the queue (close SE list).
                 # Some SEs may not be managed locally and thus not be listed into SE_HOSTS.
-                foreach (i; se; queue_close_se_list) {   
+                foreach (i; se; queue_close_se_list) {
                     if ( exists(SE_HOSTS[se]) ) {
                         params = SE_HOSTS[se];
                     } else {
                         params = undef;
                     };
-          
+
                     if ( exists(params['accessPoint']) && is_defined(params['accessPoint']) ) {
                         accesspoint = params['accessPoint'];
                     } else {
@@ -1030,12 +1048,13 @@ variable GIP_CE_LDIF_PARAMS = {
                         } else if ( params['type'] == 'SE_classic' ) {
                             accesspoint = SE_STORAGE_DIR;
                         } else {
-                            error('No default value for SE Access Point for host ' + se + ' (type=' + params['type'] + ')');
+                            error('No default value for SE Access Point for host ' +
+                                se + ' (type=' + params['type'] + ')');
                         };
                     };
-          
+
                     close_se_entries_g1[escape('dn: GlueCESEBindSEUniqueID=' + se + ',GlueCESEBindGroupCEUniqueID=' +
-                                                unique_id + ',Mds-Vo-name=resource,o=grid')] = dict(
+                        unique_id + ',Mds-Vo-name=resource,o=grid')] = dict(
                         'objectClass', list('GlueGeneralTop', 'GlueCESEBind', 'GlueSchemaVersion'),
                         'GlueSchemaVersionMajor', list('1'),
                         'GlueSchemaVersionMinor', list('3'),
@@ -1044,16 +1063,16 @@ variable GIP_CE_LDIF_PARAMS = {
                         'GlueCESEBindCEUniqueID', list(unique_id),
                         'GlueCESEBindMountInfo', list(accesspoint),
                         'GlueCESEBindWeight', list('0'),
-                    );             
-    
+                    );
+
                 };
             };
         };
-    
+
         SELF["glue1"]["lcg-info-static-cesebind.conf"]['ldifFile'] = "static-file-CESEBind.ldif";
         SELF["glue1"]["lcg-info-static-cesebind.conf"]['entries'] = close_se_entries_g1;
     };
-  
+
 
     # Create LDIF configuration entries for GLUE2 (general parameters)
     # FIXME: ServingState configuration
@@ -1118,8 +1137,8 @@ variable GIP_CE_LDIF_PARAMS = {
     # FIXME: ProcessorVendor. Define separate Execution Environments for different HW?
     # FIXME: ProcessorModel. Define separate Execution Environments for different HW?
     # FIXME: ProcessorClockSpeed. Define separate Execution Environments for different HW?
-    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {    
-        glue2_var_prefix = format('ExecutionEnvironment_%s_',GIP_CLUSTER_PUBLISHER_HOST);
+    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
+        glue2_var_prefix = format('ExecutionEnvironment_%s_', GIP_CLUSTER_PUBLISHER_HOST);
         SELF['glue2']['ExecutionEnvironment'] = dict(
             glue2_var_prefix + 'ArchitecturePlatformType', list(CE_WN_ARCH),
             glue2_var_prefix + 'PhysicalCPUs', list(to_string(CE_CPU_CONFIG['cpus'])),
@@ -1138,10 +1157,10 @@ variable GIP_CE_LDIF_PARAMS = {
             glue2_var_prefix + 'Benchmarks', list(
                 format('(hep-spec06 %s)', to_string(hepspec06)),
                 format('(specfp2000 %s)', to_string(CE_SF00)),
-                format('(specint2000 %s)',to_string(CE_SI00)),
+                format('(specint2000 %s)', to_string(CE_SI00)),
             ),
             glue2_var_prefix + 'Cores', list(to_string(average_core_num)),
-       );
+        );
     };
 
     SELF;
@@ -1159,7 +1178,7 @@ variable GIP_CE_LDIF_PARAMS = {
 
     if ( is_defined(GIP_CE_LDIF_PARAMS['glue1']) ) {
         foreach (k; v; GIP_CE_LDIF_PARAMS['glue1']) {
-           SELF['ldif'][k] = v;
+            SELF['ldif'][k] = v;
         };
     };
 
@@ -1176,9 +1195,9 @@ variable GIP_CE_LDIF_PARAMS = {
         foreach (category; dummy; GIP_CE_GLUE2_LDIF_PROCESSORS) {
             # When the host is not also the GIP_CLUSTER_PUBLISHER_HOST (in cluster mode),
             # only the GLUE2ComputingService and the GLUE2ComputingEndpoint must be published.
-            if ( (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) || match('endpoint|service',category) ) {    
+            if ( (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) || match('endpoint|service', category) ) {
                 SELF['ldif']['glue2_' + category]['staticInfoCmd'] = format(
-                    '%s/%s', 
+                    '%s/%s',
                     GIP_CE_GLUE2_LDIF_PROCESSOR_DIR,
                     GIP_CE_GLUE2_LDIF_PROCESSORS[category]
                 );
@@ -1193,7 +1212,7 @@ variable GIP_CE_LDIF_PARAMS = {
 
 
 #---------------------------------------------------------------
-# Configuration of the GlueService information provider for 
+# Configuration of the GlueService information provider for
 # CREAM CE and CEMON service.
 # Do not create if CE_FLAVOR is undefined (not a CE).
 #---------------------------------------------------------------
@@ -1209,10 +1228,10 @@ variable GIP_CE_LDIF_PARAMS = {
         if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
             service_list[length(service_list)] = 'rtepublisher';
         };
-        foreach (i;service;service_list) {
+        foreach (i; service; service_list) {
             service_owner_cmd = '';
             service_acbr_cmd = '';
-            foreach (i;vo;VOS_FULL) {
+            foreach (i; vo; VOS_FULL) {
                 service_owner_cmd = service_owner_cmd + ' echo ' + vo + ";";
                 service_acbr_cmd = service_acbr_cmd + ' echo VO:' + vo + ";";
             };
@@ -1226,17 +1245,19 @@ variable GIP_CE_LDIF_PARAMS = {
             } else {
                 error("Either 'version' or 'version_rpm' must be present in GIP_CE_SERVICE_PARAMS[" + service + "]");
             };
-      
-            SELF['confFiles'][escape(service_provider_conf)] = 
+
+            SELF['confFiles'][escape(service_provider_conf)] =
                 "init = " + GIP_PROVIDER_SUBSERVICE[service] + " init\n" +
                 "service_type = " + GIP_CE_SERVICE_PARAMS[service]['type'] + "\n" +
                 "get_version = " + service_version_cmd + "\n" +
-                "get_endpoint = echo " + GIP_CE_SERVICE_PARAMS[service]['endpoint'] +"\n" +
-                "get_status = " + GIP_PROVIDER_SUBSERVICE['test'] + " " + GIP_CE_SERVICE_PARAMS[service]['service_status_name'] +
+                "get_endpoint = echo " + GIP_CE_SERVICE_PARAMS[service]['endpoint'] + "\n" +
+                "get_status = " + GIP_PROVIDER_SUBSERVICE['test'] + " " +
+                    GIP_CE_SERVICE_PARAMS[service]['service_status_name'] +
                     " && /sbin/service " + GIP_CE_SERVICE_PARAMS[service]['service'] + " status\n" +
                 "WSDL_URL = " + GIP_CE_SERVICE_PARAMS[service]['wsdl'] + "\n" +
                 "semantics_URL = " + GIP_CE_SERVICE_PARAMS[service]['semantics'] + "\n" +
-                "get_starttime =  perl -e '@st=stat(" + GIP_CE_SERVICE_PARAMS[service]['pid_file'] + ");print \"@st[10]\\n\";'\n" +
+                "get_starttime =  perl -e '@st=stat(" + GIP_CE_SERVICE_PARAMS[service]['pid_file'] +
+                    ");print \"@st[10]\\n\";'\n" +
                 "get_owner =" + service_owner_cmd + "\n" +
                 "get_acbr =" + service_acbr_cmd + "\n" +
                 "get_data =  echo -en " + GIP_CE_SERVICE_PARAMS[service]['service_data'] + "\n" +
@@ -1244,13 +1265,14 @@ variable GIP_CE_LDIF_PARAMS = {
                 "get_implementationversion = " + service_version_cmd + "\n" +
                 "get_services = echo\n";
             SELF['provider'][service_provider_wrapper] =
-                "#!/bin/sh\n" + 
+                "#!/bin/sh\n" +
                 GIP_PROVIDER_SERVICE + ' ' + service_provider_conf + ' ' + SITE_NAME + ' ' + service_uniqueid + "\n";
 
             # Glue v2
             SELF['provider'][service_provider_wrapper + '-glue2'] =
-                "#!/bin/sh\n" + 
-                GIP_PROVIDER_SERVICE + '-glue2 ' + service_provider_conf + ' ' + SITE_NAME + ' ' + service_uniqueid + "\n";
+                "#!/bin/sh\n" +
+                GIP_PROVIDER_SERVICE + '-glue2 ' + service_provider_conf + ' ' + SITE_NAME + ' ' +
+                    service_uniqueid + "\n";
         };
     };
     SELF;
@@ -1262,24 +1284,24 @@ variable GIP_CE_LDIF_PARAMS = {
 include if ( GIP_CE_USE_MAUI && (FULL_HOSTNAME == LRMS_SERVER_HOST) ) 'features/gip/ce-maui-plugin-defaults';
 
 # Define permissions/owner for some key directories
-include { 'components/dirperm/config' };
+include 'components/dirperm/config';
 '/software/components/dirperm/paths' = {
     append(dict(
-        'owner','ldap:ldap',
+        'owner', 'ldap:ldap',
         'path', '/var/lib/bdii/db/grid',
         'perm', '0755',
         'type', 'd',
     ));
     append(dict(
-        'owner','ldap:ldap',
+        'owner', 'ldap:ldap',
         'path', '/var/lib/bdii/db/glue',
-        'perm','0755',
-        'type','d',
+        'perm', '0755',
+        'type', 'd',
     ));
     append(dict(
-        'owner','ldap:ldap',
-        'path','/var/lib/bdii/db/stats',
-        'perm','0755',
-        'type','d',
+        'owner', 'ldap:ldap',
+        'path', '/var/lib/bdii/db/stats',
+        'perm', '0755',
+        'type', 'd',
     ));
 };

--- a/features/gip/ce.pan
+++ b/features/gip/ce.pan
@@ -1,29 +1,29 @@
 unique template features/gip/ce;
 
-include { 'components/gip2/config' };
+include 'components/gip2/config';
 
 variable GIP_CE_GLUE2_CONFIG_FILE ?= 'glite-ce-glue2.conf';
 
 variable GIP_CE_GLUE2_LDIF_PROCESSOR_DIR ?= '/usr/libexec';
 
-variable GIP_CE_GLUE2_LDIF_PROCESSORS = nlist(
-  'benchmark', 'glite-ce-glue2-benchmark-static',
-  'endpoint', 'glite-ce-glue2-endpoint-static',
-  'environment', 'glite-ce-glue2-executionenvironment-static',
-  'manager', 'glite-ce-glue2-manager-static',
-  'service', 'glite-ce-glue2-computingservice-static',
-  'shares', 'glite-ce-glue2-share-static',
-  'storage', 'glite-ce-glue2-tostorageservice-static',
+variable GIP_CE_GLUE2_LDIF_PROCESSORS = dict(
+    'benchmark', 'glite-ce-glue2-benchmark-static',
+    'endpoint', 'glite-ce-glue2-endpoint-static',
+    'environment', 'glite-ce-glue2-executionenvironment-static',
+    'manager', 'glite-ce-glue2-manager-static',
+    'service', 'glite-ce-glue2-computingservice-static',
+    'shares', 'glite-ce-glue2-share-static',
+    'storage', 'glite-ce-glue2-tostorageservice-static',
 );
 
-variable GIP_CE_GLUE2_LDIF_FILES = nlist(
-  'benchmark', 'Benchmark.ldif',
-  'endpoint', 'ComputingEndpoint.ldif',
-  'environment', 'ExecutionEnvironment.ldif',
-  'manager', 'ComputingManager.ldif',
-  'service', 'ComputingService.ldif',
-  'shares', 'ComputingShare.ldif',
-  'storage', 'ToStorageService.ldif',
+variable GIP_CE_GLUE2_LDIF_FILES = dict(
+    'benchmark', 'Benchmark.ldif',
+    'endpoint', 'ComputingEndpoint.ldif',
+    'environment', 'ExecutionEnvironment.ldif',
+    'manager', 'ComputingManager.ldif',
+    'service', 'ComputingService.ldif',
+    'shares', 'ComputingShare.ldif',
+    'storage', 'ToStorageService.ldif',
 );
 
 variable GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE ?= '/etc/lrms/lcg-info-dynamic-maui.defaults';
@@ -33,7 +33,7 @@ variable CE_OS_FAMILY ?= 'linux';
 
 @{
 desc = define VO shares to be applied to each CE
-values = percentage
+values = percentage 
 default = none
 required = no
 }
@@ -70,15 +70,16 @@ variable CE_HOSTS_CREAM ?= list();
 variable CE_HOSTS_LCG ?= list();
 
 variable CE_FLAVOR ?= if ( is_defined(CE_HOSTS_CREAM) && (index(FULL_HOSTNAME,CE_HOSTS_CREAM) >= 0) ) {
-                        'cream';
-                      } else {
-                        undef;
-                      };
+    'cream';
+} else {
+    undef;
+};
+
 variable CE_FLAVOR = {
-  if ( is_defined(CE_FLAVOR) && !match(CE_FLAVOR,'cream') ) {
-    error("Invalid value for CE_FLAVOR ("+CE_FLAVOR+"). Must be 'cream'.");
-  };
-  SELF;
+    if ( is_defined(CE_FLAVOR) && !match(CE_FLAVOR,'cream') ) {
+        error("Invalid value for CE_FLAVOR (" + CE_FLAVOR + "). Must be 'cream'.");
+    };
+    SELF;
 };
 
 # Default static value for several job-related attributes (updated by dynamic info providers)
@@ -89,6 +90,7 @@ variable GLUE_FAKE_JOB_VALUE ?= 444444;
 # several CEs share the same cluster/WNs.
 # Default: LRMS master node.
 variable GIP_CLUSTER_PUBLISHER_HOST ?= LRMS_SERVER_HOST;
+variable LRMS_PRIMARY_SERVER_HOST ?= LRMS_SERVER_HOST;
 
 # Variables related to MAUI-based GIP plugin.
 # Enable/disable its use instead of Torque-based plugin. Default: enabled.
@@ -107,32 +109,32 @@ variable PKG_ARCH_TORQUE_MAUI ?= PKG_ARCH_GLITE;
 # plugin. There must be at least one entry for each one present in GIP_CE_PLUGIN_COMMAND.
 # NOTE: this feature is currently implemented only for MAUI-based plugins.
 variable GIP_CE_CACHE_FILE ?= if ( GIP_CE_USE_CACHE ) {
-                                if ( ( length(CE_HOSTS) == 1 ) && ( LRMS_SERVER_HOST == CE_HOSTS[0] ) ) {
-                                  SELF['ce'] = '/tmp/gip-ce-dynamic-info-maui.cache';
-                                  SELF['scheduler'] = '/tmp/gip-ce-dynamic-info-scheduler.cache';
-                                } else {
-                                  if ( is_defined(VO_SW_AREAS['dteam']) ) {
-                                    SELF['ce'] = VO_SW_AREAS['dteam']+'/gip-ce-dynamic-info-maui.cache';
-                                    SELF['scheduler'] = VO_SW_AREAS['dteam']+'/gip-ce-dynamic-info-scheduler.cache';
-                                  } else if ( is_defined(VO_SW_AREAS['DEFAULT']) ) {
-                                    SELF['ce'] = VO_SW_AREAS['DEFAULT']+'/gip-ce-dynamic-info-maui.cache';
-                                    SELF['scheduler'] = VO_SW_AREAS['DEFAULT']+'/gip-ce-dynamic-info-scheduler.cache';
-                                  } else {
-                                    error("Unabled to compute default value for GIP_CE_CACHE_FILE. Define explicitly");
-                                  };
-                                };
-                                SELF;
-                              } else {
-                                undef;
-                              };
+    if ( ( length(CE_HOSTS) == 1 ) && ( LRMS_SERVER_HOST == CE_HOSTS[0] ) ) {
+        SELF['ce'] = '/tmp/gip-ce-dynamic-info-maui.cache';
+        SELF['scheduler'] = '/tmp/gip-ce-dynamic-info-scheduler.cache';
+    } else {
+        if ( is_defined(VO_SW_AREAS['dteam']) ) {
+            SELF['ce'] = VO_SW_AREAS['dteam'] + '/gip-ce-dynamic-info-maui.cache';
+            SELF['scheduler'] = VO_SW_AREAS['dteam'] + '/gip-ce-dynamic-info-scheduler.cache';
+        } else if ( is_defined(VO_SW_AREAS['DEFAULT']) ) {
+            SELF['ce'] = VO_SW_AREAS['DEFAULT'] + '/gip-ce-dynamic-info-maui.cache';
+            SELF['scheduler'] = VO_SW_AREAS['DEFAULT'] + '/gip-ce-dynamic-info-scheduler.cache';
+        } else {
+            error("Unabled to compute default value for GIP_CE_CACHE_FILE. Define explicitly");
+        };
+    };
+    SELF;
+} else {
+    undef;
+};
 
 
 # CE close SE list
 variable CE_CLOSE_SE_LIST ?= undef;
 
 # CE port for each CE flavor
-variable CE_PORT = nlist(
-  'cream', 8443,
+variable CE_PORT = dict(
+    'cream', 8443,
 );
 
 # For GlueHostArchitecturePlatformType, assume the same type as CE until we support several subclusters
@@ -140,8 +142,8 @@ variable CE_PORT = nlist(
 variable CE_WN_ARCH ?= PKG_ARCH_DEFAULT;
 
 # CE implementation for each flavor
-variable GLUE_CE_IMPLEMENTATION = nlist(
-  'cream',    'CREAM',
+variable GLUE_CE_IMPLEMENTATION = dict(
+    'cream', 'CREAM',
 );
 
 # Which version of tomcat
@@ -152,180 +154,189 @@ variable TOMCAT_SERVICE ?= 'tomcat6';
 # GIP_CE_SERVICES defines the list of GlueService to publish for each CE flavor: there must be one matching
 # entry for each value in GIP_CE_SERVICE_PARAMS.
 variable GIP_PROVIDER_SERVICE_CONF_BASE ?= GIP_SCRIPTS_CONF_DIR + '/glite-info-service';
-variable GIP_CE_SERVICES = nlist(
-  'cream',    list('creamce','cemon'),
+variable GIP_CE_SERVICES = dict(
+    'cream',  list('creamce', 'cemon'),
 );
-variable GIP_PROVIDER_SUBSERVICE ?= nlist(
-  'creamce',    GIP_SCRIPTS_DIR + '/glite-info-service-cream',
-  'cemon',      GIP_SCRIPTS_DIR + '/glite-info-service-cream',
-  'gatekeeper', GIP_SCRIPTS_DIR + '/glite-info-service-gatekeeper',
-  'rtepublisher', GIP_SCRIPTS_DIR + '/glite-info-service-rtepublisher',
-  'test',       GIP_SCRIPTS_DIR + '/glite-info-service-test',
+variable GIP_PROVIDER_SUBSERVICE ?= dict(
+    'creamce', GIP_SCRIPTS_DIR + '/glite-info-service-cream',
+    'cemon', GIP_SCRIPTS_DIR + '/glite-info-service-cream',
+    'gatekeeper', GIP_SCRIPTS_DIR + '/glite-info-service-gatekeeper',
+    'rtepublisher', GIP_SCRIPTS_DIR + '/glite-info-service-rtepublisher',
+    'test', GIP_SCRIPTS_DIR + '/glite-info-service-test',
 );
-variable GIP_CE_SERVICE_PARAMS = nlist(
-  'creamce',      nlist('type', 'org.glite.ce.CREAM',
-                        'endpoint', 'https://${CREAM_HOST}:${CREAM_PORT}/ce-cream/services',
-                        'service', TOMCAT_SERVICE,
-                        'service_status_name', 'CREAM',
-                        'version_rpm', 'glite-ce-cream',
-                        'pid_file', '$ENV{CREAM_PID_FILE}',
-                        'wsdl', 'http://grid.pd.infn.it/cream/wsdl/org.glite.ce-cream_service.wsdl',
-                        'semantics', 'https://edms.cern.ch/document/595770',
-                        'service_data', '',
-                        'implementationname', 'CREAM',
-                       ),
-  'cemon',        nlist('type', 'org.glite.ce.Monitor',
-                        'endpoint', 'https://${CREAM_HOST}:${CREAM_PORT}/ce-monitor/services/CEMonitor',
-                        'service', TOMCAT_SERVICE,
-                        'service_status_name', 'CEMON',
-                        'version_rpm', 'glite-ce-monitor',
-                        'pid_file', '$ENV{CREAM_PID_FILE}',
-                        'wsdl', 'http://grid.pd.infn.it/cemon/wsdl/org.glite.ce-mon_service.wsdl',
-                        'semantics', 'https://edms.cern.ch/document/585040',
-                        'service_data', '',
-                        'implementationname', 'CEmon',
-                       ),
-  'gatekeeper',   nlist('type', 'org.edg.gatekeeper',
-                        'endpoint', 'gram://$GATEKEEPER_HOST:$GATEKEEPER_PORT/',
-                        'service', 'globus-gatekeeper',
-                        'service_status_name', 'GATEKEEPER',
-                        'version', '2.0.0',
-                        'pid_file', '$ENV{GATEKEEPER_PROCDIR}',
-                        'wsdl', 'nohttp://not.a.web.service/',
-                        'semantics', 'http://www.globus.org/toolkit/docs/2.4/gram/',
-                        'service_data', '"Services=$GATEKEEPER_SERVICES\nDN=" && grid-cert-info -file /etc/grid-security/hostcert.pem -subject',
-                        'implementationname', 'GateKeeper',
-                       ),
-  'rtepublisher', nlist('type', 'org.glite.RTEPublisher',
-                      'endpoint', 'gsiftp://$RTEPUBLISHER_HOST:$RTEPUBLISHER_PORT'+VO_SW_TAGS_DIR,
-                      'service', 'globus-gridftp',
-                      'service_status_name', 'RTEPUBLISHER',
-                      'version', 'echo 1.0.0',
-                      'pid_file', '$ENV{GRIDFTP_PROC_FILE}',
-                      'wsdl', 'nohttp://not.a.web.service/',
-                      'semantics', ' http://grid-deployment.web.cern.ch/grid-deployment/eis/docs/ExpSwInstall/sw-install.html',
-                      'service_data', GIP_CLUSTER_PUBLISHER_HOST,
-                      'implementationname', 'ApplicationPublisher',
-                     ),
+variable GIP_CE_SERVICE_PARAMS = dict(
+    'creamce',  dict(
+        'type', 'org.glite.ce.CREAM',
+        'endpoint', 'https://${CREAM_HOST}:${CREAM_PORT}/ce-cream/services',
+        'service', TOMCAT_SERVICE,
+        'service_status_name', 'CREAM',
+        'version_rpm', 'glite-ce-cream',
+        'pid_file', '$ENV{CREAM_PID_FILE}',
+        'wsdl', 'http://grid.pd.infn.it/cream/wsdl/org.glite.ce-cream_service.wsdl',
+        'semantics', 'https://edms.cern.ch/document/595770',
+        'service_data', '',
+        'implementationname', 'CREAM',
+    ),
+    'cemon', dict(
+        'type', 'org.glite.ce.Monitor',
+        'endpoint', 'https://${CREAM_HOST}:${CREAM_PORT}/ce-monitor/services/CEMonitor',
+        'service', TOMCAT_SERVICE,
+        'service_status_name', 'CEMON',
+        'version_rpm', 'glite-ce-monitor',
+        'pid_file', '$ENV{CREAM_PID_FILE}',
+        'wsdl', 'http://grid.pd.infn.it/cemon/wsdl/org.glite.ce-mon_service.wsdl',
+        'semantics', 'https://edms.cern.ch/document/585040',
+        'service_data', '',
+        'implementationname', 'CEmon',
+    ),
+    'gatekeeper', dict(
+        'type', 'org.edg.gatekeeper',
+        'endpoint', 'gram://$GATEKEEPER_HOST:$GATEKEEPER_PORT/',
+        'service', 'globus-gatekeeper',
+        'service_status_name', 'GATEKEEPER',
+        'version', '2.0.0',
+        'pid_file', '$ENV{GATEKEEPER_PROCDIR}',
+        'wsdl', 'nohttp://not.a.web.service/',
+        'semantics', 'http://www.globus.org/toolkit/docs/2.4/gram/',
+        'service_data', '"Services=$GATEKEEPER_SERVICES\nDN=" && grid-cert-info -file /etc/grid-security/hostcert.pem -subject',
+        'implementationname', 'GateKeeper',
+    ),
+    'rtepublisher', dict(
+        'type', 'org.glite.RTEPublisher',
+        'endpoint', 'gsiftp://$RTEPUBLISHER_HOST:$RTEPUBLISHER_PORT'+VO_SW_TAGS_DIR,
+        'service', 'globus-gridftp',
+        'service_status_name', 'RTEPUBLISHER',
+        'version', 'echo 1.0.0',
+        'pid_file', '$ENV{GRIDFTP_PROC_FILE}',
+        'wsdl', 'nohttp://not.a.web.service/',
+        'semantics', ' http://grid-deployment.web.cern.ch/grid-deployment/eis/docs/ExpSwInstall/sw-install.html',
+        'service_data', GIP_CLUSTER_PUBLISHER_HOST,
+        'implementationname', 'ApplicationPublisher',
+    ),
 );
 
 
 
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 # Add RPMs that are required by GIP on CE to update dynamic information
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 '/software/packages' = {
-  pkg_repl('glite-ce-cream-utils');
-  pkg_repl('glite-info-provider-service');
-  if(CE_BATCH_SYS == 'pbs' || CE_BATCH_SYS == 'torque'){
-    pkg_repl('lcg-info-dynamic-scheduler-pbs');
-    if ( GIP_CE_USE_MAUI ) pkg_repl('lcg-info-dynamic-maui');
-  };
-  if(CE_BATCH_SYS == 'condor'){ pkg_repl('dynsched-generic');};
-  SELF;
+    pkg_repl('glite-ce-cream-utils');
+    pkg_repl('glite-info-provider-service');
+    if(CE_BATCH_SYS == 'pbs' || CE_BATCH_SYS == 'torque'){
+        pkg_repl('lcg-info-dynamic-scheduler-pbs');
+        if ( GIP_CE_USE_MAUI ) pkg_repl('lcg-info-dynamic-maui');
+    };
+    if(CE_BATCH_SYS == 'condor'){ pkg_repl('dynsched-generic');};
+    SELF;
 };
 
 
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 # HTCondor: add required scripts not part of official RPMs
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 
 # Necessary only the GIP_CLUSTER_PUBLISHER_HOST (generally LRMS_SERVER_HOST)
 include  if( (CE_BATCH_SYS == 'condor') && (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) ) 'features/gip/ce-condor-plugins';
 
 
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 # Compute several variables summarizing the configuration
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 
 variable CE_DATADIR ?= 'unset';
 
 #Build  GlueCECapability entry to publish
 variable CE_CAPABILITIES = {
-      SELF[length(SELF)] = 'CPUScalingReferenceSI00='+to_string(CE_SI00);
-      if ( is_defined(CE_VO_SHARES) ) {
-        foreach (i;v;CE_VO_SHARES) {
-          SELF[length(SELF)] = 'Share='+i+":"+to_string(v);
+    SELF[length(SELF)] = 'CPUScalingReferenceSI00=' + to_string(CE_SI00);
+    if ( is_defined(CE_VO_SHARES) ) {
+        foreach (i; v; CE_VO_SHARES) {
+            SELF[length(SELF)] = 'Share=' + i + ":" + to_string(v);
         };
-      };
-      SELF;
+    };
+    SELF;
 };
 
 
-variable CE_STATE_STATUS =
-  if ( exists(CE_STATUS) && is_defined(CE_STATUS) ) {
+variable CE_STATE_STATUS = if ( exists(CE_STATUS) && is_defined(CE_STATUS) ) {
     CE_STATUS;
-  } else {
+} else {
     'Production';
-  };
+};
 
 # Default queue configuration if not explicitly defined before.
 # This will create one queue per VO with the queue name equal
 # to the VO name and an empty 'attlist' for each queue.
-# The format is a nlist made of 2 nlists : 'vos' lists for each queue
+# The format is a dict made of 2 dicts : 'vos' lists for each queue
 # the VO with an access to it and 'attlist' lists for each queue the
 # specific queue attributes.
 variable CE_QUEUES ?= {
-  queues = nlist();
-  queues['vos'] = nlist();
-  queues['attlist'] = nlist();
+    queues = dict();
+    queues['vos'] = dict();
+    queues['attlist'] = dict();
 
-  foreach (k;v;VOS) {
-    queues['vos'][v] = list(v);
-  };
-  queues;
+    foreach (k; v; VOS) {
+        queues['vos'][v] = list(v);
+    };
+    queues;
 };
 
 # List of batch system configured.
 # In addition to the default batch system (CE_BATCH_SYS_LIST), some queues may be declared
 # to use another one.
-# The batch system list is a nlist where keys are batch systems (job managers) as specified
+# The batch system list is a dict where keys are batch systems (job managers) as specified
 # in the configuration and the value the corresponding generic batch system name
 # (ex: 'pbs' for 'lcgpbs'). For most batch systems, the key and the value are equal.
 variable CE_BATCH_SYS_LIST ?= {
-  SELF[CE_BATCH_SYS] = CE_BATCH_SYS;
+    SELF[CE_BATCH_SYS] = CE_BATCH_SYS;
 
-  nondef_lrms=nlist();
-  if ( exists(CE_QUEUES['lrms']) && is_defined(CE_QUEUES['lrms']) ) {
-    foreach (queue;lrms;CE_QUEUES['lrms']) {
-      if ( !exists(SELF[lrms]) ) {
-        SELF[lrms] = lrms;
-      };
+    nondef_lrms=dict();
+    if ( exists(CE_QUEUES['lrms']) && is_defined(CE_QUEUES['lrms']) ) {
+        foreach (queue;lrms;CE_QUEUES['lrms']) {
+            if ( !exists(SELF[lrms]) ) {
+                SELF[lrms] = lrms;
+            };
+        };
     };
-  };
-
-  # Update value for some specific job managers
-  foreach (jobmanager;lrms;SELF) {
-    if ( match(lrms, 'lcgpbs|torque') ) {
-      SELF[jobmanager] = 'pbs';
-    } else if ( lrms == 'CONDOR' ) {
-      SELF[jobmanager] = 'condor';
+  
+    # Update value for some specific job managers
+    foreach (jobmanager;lrms;SELF) {
+        if ( match(lrms, 'lcgpbs|torque') ) {
+            SELF[jobmanager] = 'pbs';
+        } else if ( lrms == 'CONDOR' ) {
+            SELF[jobmanager] = 'condor';
+        };
     };
-  };
 
-  debug('List of configured batch systems: '+to_string(SELF));
-  SELF;
+    debug('List of configured batch systems: ' + to_string(SELF));
+    SELF;
 };
 
 # Compute number of sockets (CPUs) and cores.
 # If the variable defining this for each WN based on HW configuration
 # is not defined, rely on WN_CPUS variable.
 variable CE_CPU_CONFIG = {
-  SELF['cpus'] = 0;
-  SELF['cores'] = 0;
-  SELF['slots'] = 0;
-  foreach (i;wn;WORKER_NODES) {
-    if ( is_defined(WN_CPU_CONFIG[wn]) ) {
-      SELF['cpus'] = SELF['cpus'] + WN_CPU_CONFIG[wn]['cpus'];
-      SELF['cores'] = SELF['cores'] + WN_CPU_CONFIG[wn]['cores'];
-      SELF['slots'] = SELF['slots'] + WN_CPU_CONFIG[wn]['slots'];
-    } else {
-      error('Failed to find '+wn+' CPU configuration in WN_CPU_CONFIG');
+    SELF['cpus'] = 0;
+    SELF['cores'] = 0;
+    SELF['slots'] = 0;
+    foreach (i; wn; WORKER_NODES) {
+        if ( is_defined(WN_CPU_CONFIG[wn]) ) {
+            SELF['cpus'] = SELF['cpus'] + WN_CPU_CONFIG[wn]['cpus'];
+            SELF['cores'] = SELF['cores'] + WN_CPU_CONFIG[wn]['cores'];
+            SELF['slots'] = SELF['slots'] + WN_CPU_CONFIG[wn]['slots'];
+        } else {
+            error('Failed to find ' + wn + ' CPU configuration in WN_CPU_CONFIG');
+        };
     };
-  };
-  SELF;
-};
+    if(SELF['cpus'] == 0){
+        SELF['cpus'] = 1;
+        SELF['cores'] = 1;
+        SELF['slots'] = 1;
+    };
 
+    SELF;
+};
+   
 # Build the command to use to run the MAUI-based GIP plugins. Depending if it is run directly by the GIP or
 # used in cache mode, this wrapper will be configured as a GIP plugin or as a script to be run by some other
 # scripts (generally maui-monitoring).
@@ -334,154 +345,168 @@ variable CE_CPU_CONFIG = {
 # NOTE: this feature is currently implemented only for MAUI-based plugins.
 # FIXME: generalize this feature for all batch systems
 variable GIP_CE_PLUGIN_COMMAND = {
-  # If using the standard Torque-based plugin, do nothing
-  if ( GIP_CE_USE_MAUI ) {
-    # MAUI-based plugin requires an architecture-dependent python module.
-    # To allow Torque 32-bit on an OS 64-bit, select python version to use
-    # explictly in the wrapper. Assume /opt/glite/bin/python2 is configured properly to
-    # launch the 32-bit version on a 64-bit OS.
-    if ( (PKG_ARCH_DEFAULT == 'x86_64') && (PKG_ARCH_TORQUE_MAUI == 'i386') ) {
-      pythonbin = EMI_LOCATION+'/bin/python2';
-    } else {
-      pythonbin = 'python'
+    # If using the standard Torque-based plugin, do nothing
+    if ( GIP_CE_USE_MAUI ) {
+        # MAUI-based plugin requires an architecture-dependent python module.
+        # To allow Torque 32-bit on an OS 64-bit, select python version to use
+        # explictly in the wrapper. Assume /opt/glite/bin/python2 is configured properly to
+        # launch the 32-bit version on a 64-bit OS.
+        if ( (PKG_ARCH_DEFAULT == 'x86_64') && (PKG_ARCH_TORQUE_MAUI == 'i386') ) {
+            pythonbin = EMI_LOCATION + '/bin/python2';
+        } else {
+            pythonbin = 'python'
+        };
+        gip_script_options = format("--max-normal-slots %d --defaults %s", CE_CPU_CONFIG['slots'], GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE);
+        SELF['ce'] = pythonbin + ' ' + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-maui --host "+LRMS_SERVER_HOST+" "+gip_script_options;
+        # FIXME: lcg-info-dynamic-scheduler doesn't allow to use a LDIF file in a non standard location...
+        # Update to whatever is appropriate in cache mode when this is fixed.
+        if ( GIP_CE_USE_CACHE ) {
+            SELF['ce'] = SELF['ce'] + format(
+                 ' --ce-ldif %s --share-ldif %s',
+                 GIP_LDIF_DIR + '/static-file-all-CE-pbs.ldif',
+                 GIP_LDIF_DIR + '/'+GIP_CE_GLUE2_LDIF_FILES['shares']
+            );
+        } else {
+            SELF['ce'] = SELF['ce'] + format(
+                ' --ce-ldif %s --share-ldif %s',
+                GIP_LDIF_DIR + '/static-file-all-CE-pbs.ldif',
+                GIP_LDIF_DIR + '/' + GIP_CE_GLUE2_LDIF_FILES['shares']
+            );
+        };
     };
-    gip_script_options = format("--max-normal-slots %d --defaults %s", CE_CPU_CONFIG['slots'], GIP_CE_MAUI_PLUGIN_DEFAULTS_FILE);
-    SELF['ce'] = pythonbin + ' ' + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-maui --host "+LRMS_SERVER_HOST+" "+gip_script_options;
-    # FIXME: lcg-info-dynamic-scheduler doesn't allow to use a LDIF file in a non standard location...
-    # Update to whatever is appropriate in cache mode when this is fixed.
+
+    # Define only if using cache mode
     if ( GIP_CE_USE_CACHE ) {
-      SELF['ce'] = SELF['ce'] + format(' --ce-ldif %s --share-ldif %s', GIP_LDIF_DIR+'/static-file-all-CE-pbs.ldif',
-                                                                        GIP_LDIF_DIR+'/'+GIP_CE_GLUE2_LDIF_FILES['shares']);
-    } else {
-      SELF['ce'] = SELF['ce'] + format(' --ce-ldif %s --share-ldif %s', GIP_LDIF_DIR+'/static-file-all-CE-pbs.ldif',
-                                                                        GIP_LDIF_DIR+'/'+GIP_CE_GLUE2_LDIF_FILES['shares']);
+        SELF['scheduler'] = '';
+        foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
+            # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots
+            # to be computing by lcg-info-dynamic-maui rather than
+            # lcg-info-dynamic-scheduler
+            if ( (lrms == 'pbs') && GIP_CE_USE_MAUI ) {
+                remove_free_slots_cmd = '| grep -v GLUE2ComputingShareFreeSlots';
+            } else {
+                remove_free_slots_cmd = '';
+            };
+            SELF['scheduler'] = SELF['scheduler'] + format(
+                '%s/lcg-info-dynamic-scheduler -c %s/lcg-info-dynamic-scheduler-%s.conf %s',
+                LCG_INFO_SCRIPTS_DIR,
+                GIP_SCRIPTS_CONF_DIR,
+                lrms,
+                remove_free_slots_cmd,
+            );
+        };
     };
-  };
-
-  # Define only if using cache mode
-  if ( GIP_CE_USE_CACHE ) {
-      SELF['scheduler'] = '';
-    foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
-      # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots to be computing by lcg-info-dynamic-maui rather than
-      # lcg-info-dynamic-scheduler
-      if ( (lrms == 'pbs') && GIP_CE_USE_MAUI ) {
-        remove_free_slots_cmd = '| grep -v GLUE2ComputingShareFreeSlots';
-      } else {
-        remove_free_slots_cmd = '';
-      };
-      SELF['scheduler'] = SELF['scheduler'] + format('%s/lcg-info-dynamic-scheduler -c %s/lcg-info-dynamic-scheduler-%s.conf %s',
-                                                     LCG_INFO_SCRIPTS_DIR,
-                                                     GIP_SCRIPTS_CONF_DIR,
-                                                     lrms,
-                                                     remove_free_slots_cmd,
-                                                    );
-    };
-  };
-
-  SELF;
+  
+    SELF;
 };
 
 
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 # Configure GIP plugins used to update dynamic information
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------- 
 
 "/software/components/gip2/plugin" = {
-  if ( is_defined(SELF) && !is_nlist(SELF) ) {
-    error('/software/components/gip2/plugin must be an nlist');
-  };
+    if ( is_defined(SELF) && !is_dict(SELF) ) {
+        error('/software/components/gip2/plugin must be an dict');
+    };
+  
+    # iterate over supported batch systems
+    if ( is_defined(CE_BATCH_SYS_LIST) && (length(CE_BATCH_SYS_LIST) > 0) ) {
+        contents = "";
 
-  # iterate over supported batch systems
-  if ( is_defined(CE_BATCH_SYS_LIST) && (length(CE_BATCH_SYS_LIST) > 0) ) {
-    contents = "";
-
-    foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
-      if ( lrms == "condor" ) {
-        # Do it only the GIP_CLUSTER_PUBLISHER_HOST, not on all CEs
-        if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
-          if ( !is_defined(GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN) ) {
-            error('Internal error: GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN variable undefined');
-          };
-          contents = contents + "/usr/libexec/" + GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN + " --scheduler " + CE_HOST +
+        foreach (jobmanager; lrms; CE_BATCH_SYS_LIST) {
+            if ( lrms == "condor" ) {
+                # Do it only the GIP_CLUSTER_PUBLISHER_HOST, not on all CEs
+                if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
+                    if ( !is_defined(GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN) ) {
+                        error('Internal error: GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN variable undefined');
+                    };
+                    contents = contents + "/usr/libexec/" + GIP_CE_CONDOR_INFO_DYNAMIC_PLUGIN +
+                                " --scheduler " + CE_HOST +
                                 " --glue1-ldif /var/lib/bdii/gip/ldif/static-file-all-CE-condor.ldif" +
-                                " --glue2-ldif /var/lib/bdii/gip/ldif/ComputingShare.ldif\n";
-          GIP_LDIF_DIR + "/static-file-all-CE-"+lrms+".ldif "+CONDOR_HOST+"\n";
+                                " --glue2-ldif /var/lib/bdii/gip/ldif/ComputingShare.ldif" + 
+				" --ee-ldif /var/lib/bdii/gip/ldif/ExecutionEnvironment.ldif\n";
+                    GIP_LDIF_DIR + "/static-file-all-CE-"+lrms+".ldif "+CONDOR_HOST+"\n";
+                };
+
+            } else if ( lrms == "lsf" ) {
+                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-lsf /usr/local/lsf/bin/ "+
+                            GIP_LDIF_DIR + "/static-file-CE-" + lrms + ".ldif" + "\n";
+
+            } else if ( lrms == "remotepbs" ) {
+                contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-remotepbs "+REMOTEPBS_REMOTE_HOST+
+                                                                             " "+REMOTEPBS_REMOTE_PORT+"\n";   
+            } else if ( lrms == "pbs" ) {
+                # When using MAUI-based GIP plugin, GIP wrapper runs the plugin directly if not using the cache mode
+                # or just read the cache file if used in cache mode.
+                if ( GIP_CE_USE_MAUI ) {
+                    if ( GIP_CE_USE_CACHE ) {
+                         # Just display the content. If the file doesn't exist, error will be detected/reported by GIP.
+                         contents = contents + 'cat ' + GIP_CE_CACHE_FILE['ce'];
+                    } else {
+                         contents = contents + "export PYTHONPATH=$PYTHONPATH:/usr/lib/python\n"+ GIP_CE_PLUGIN_COMMAND['ce'];
+                    };
+                } else {
+                    if ( is_defined(LRMS_SERVER_HOST) ) {
+                        contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-pbs " + GIP_LDIF_DIR +
+                                    "/static-file-CE-" + lrms + ".ldif " + LRMS_SERVER_HOST + "\n";
+                    } else {
+                        contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-pbs " + GIP_LDIF_DIR +
+                                    "/static-file-CE-" + lrms + ".ldif " + CE_HOST + "\n";  
+                   };
+               };
+           } else {
+               error("unrecognized batch system (" + lrms + "); can't configure gip CE information");
+           };
         };
 
-      } else if ( lrms == "lsf" ) {
-        contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-lsf /usr/local/lsf/bin/ "+
-            GIP_LDIF_DIR + "/static-file-CE-"+lrms+".ldif"+"\n";
+        if ( length(contents) > 0 ) {
+            SELF['lcg-info-dynamic-ce'] = "#!/bin/sh\n" + contents;
+        };
+    };
 
-      } else if ( lrms == "remotepbs" ) {
-        contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-remotepbs "+REMOTEPBS_REMOTE_HOST+
-                                                                             " "+REMOTEPBS_REMOTE_PORT+"\n";
-      } else if ( lrms == "pbs" ) {
-        # When using MAUI-based GIP plugin, GIP wrapper runs the plugin directly if not using the cache mode
-        # or just read the cache file if used in cache mode.
-        if ( GIP_CE_USE_MAUI ) {
-          if ( GIP_CE_USE_CACHE ) {
-            # Just display the content. If the file doesn't exist, error will be detected/reported by GIP.
-            contents = contents + 'cat ' + GIP_CE_CACHE_FILE['ce'];
-          } else {
-            contents = contents + "export PYTHONPATH=$PYTHONPATH:/usr/lib/python\n"+ GIP_CE_PLUGIN_COMMAND['ce'];
-          };
-        } else {
-            if ( is_defined(LRMS_SERVER_HOST) ) {
-                contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-pbs " + GIP_LDIF_DIR + "/static-file-CE-"+lrms+".ldif "+LRMS_SERVER_HOST+"\n";
+    SELF;
+};
+
+# Plugin to compute number of running jobs and ERT 
+"/software/components/gip2/plugin" = {
+    # iterate over supported batch systems
+    if ( is_defined(CE_BATCH_SYS_LIST) && (length(CE_BATCH_SYS_LIST) > 0) ) {
+        contents = "#!/bin/sh\n";
+
+        foreach (jobmanager; lrms; CE_BATCH_SYS_LIST) {
+            if ( lrms == "remotepbs" ) {
+                contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-remotepbs "+
+                            REMOTEPBS_REMOTE_HOST + " " + REMOTEPBS_REMOTE_PORT_SCHED + "\n";
+            } else if ( (lrms == 'pbs') && (is_defined(GIP_CE_PLUGIN_COMMAND['scheduler'])) && GIP_CE_USE_CACHE ) {
+                # Just display the content of cache file if cache mode is used. If the file doesn't exist, error will be detected/reported by GIP.
+                contents = contents + 'cat ' + GIP_CE_CACHE_FILE['scheduler'];
             } else {
-                contents = contents + LCG_INFO_SCRIPTS_DIR +"/lcg-info-dynamic-pbs " + GIP_LDIF_DIR + "/static-file-CE-"+lrms+".ldif "+CE_HOST+"\n";
+                # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots to be computing by lcg-info-dynamic-maui rather than
+                # lcg-info-dynamic-scheduler
+                if ( (lrms == 'pbs') && GIP_CE_USE_MAUI ) {
+                    remove_free_slots_cmd = '| grep -v GLUE2ComputingShareFreeSlots';
+                } else {
+                    remove_free_slots_cmd = '';
+                };
+                contents = contents + format(
+                    '%s/lcg-info-dynamic-scheduler -c %s/lcg-info-dynamic-scheduler-%s.conf %s',
+                    LCG_INFO_SCRIPTS_DIR,
+                    GIP_SCRIPTS_CONF_DIR,
+                    lrms,
+                    remove_free_slots_cmd,
+               );
             };
         };
-      } else {
-        error("unrecognized batch system ("+lrms+"); can't configure gip CE information");
-      };
+
+        SELF['lcg-info-dynamic-scheduler-wrapper'] = contents;
     };
 
-    if ( length(contents) > 0 ) {
-      SELF['lcg-info-dynamic-ce'] = "#!/bin/sh\n" + contents;
-    };
-  };
-
-  SELF;
-};
-
-# Plugin to compute number of running jobs and ERT
-"/software/components/gip2/plugin" = {
-  # iterate over supported batch systems
-  if ( is_defined(CE_BATCH_SYS_LIST) && (length(CE_BATCH_SYS_LIST) > 0) ) {
-    contents = "#!/bin/sh\n";
-
-    foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
-      if ( lrms == "remotepbs" ) {
-        contents = contents + LCG_INFO_SCRIPTS_DIR + "/lcg-info-dynamic-remotepbs "+REMOTEPBS_REMOTE_HOST+" "+REMOTEPBS_REMOTE_PORT_SCHED+"\n";
-      } else if ( (lrms == 'pbs') && (is_defined(GIP_CE_PLUGIN_COMMAND['scheduler'])) && GIP_CE_USE_CACHE ) {
-        # Just display the content of cache file if cache mode is used. If the file doesn't exist, error will be detected/reported by GIP.
-        contents = contents + 'cat ' + GIP_CE_CACHE_FILE['scheduler'];
-      } else {
-        # The pipe is a workaround to allow GLUE2ComputingShareFreeSlots to be computing by lcg-info-dynamic-maui rather than
-        # lcg-info-dynamic-scheduler
-        if ( (lrms == 'pbs') && GIP_CE_USE_MAUI ) {
-          remove_free_slots_cmd = '| grep -v GLUE2ComputingShareFreeSlots';
-        } else {
-          remove_free_slots_cmd = '';
-        };
-        contents = contents + format('%s/lcg-info-dynamic-scheduler -c %s/lcg-info-dynamic-scheduler-%s.conf %s',
-                                     LCG_INFO_SCRIPTS_DIR,
-                                     GIP_SCRIPTS_CONF_DIR,
-                                     lrms,
-                                     remove_free_slots_cmd,
-                                    );
-      };
-    };
-
-    SELF['lcg-info-dynamic-scheduler-wrapper'] = contents;
-  };
-
-  SELF;
+    SELF;
 };
 
 variable GIP_CE_VOMAP ?= {
-    this = nlist();
+    this = dict();
     vomap_empty = true;
     foreach (k; vo; VOS) {
         if (vo != VO_INFO[vo]['name']) {
@@ -498,62 +523,59 @@ variable GIP_CE_VOMAP ?= {
 
 # ERT configuration
 "/software/components/gip2/scripts" = {
-  if ( is_defined(SELF) && !is_nlist(SELF) ) {
-    error('/software/components/gip2/scripts must be an nlist');
-  };
-
-  # iterate over supported batch systems
-  if ( is_defined(CE_BATCH_SYS_LIST) ) {
-    foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
-      if ( lrms == "pbs" ) {
-        if ( GIP_CE_USE_CACHE ) {
-          static_ldif_dir = GIP_VAR_DIR;
-        } else {
-          static_ldif_dir = GIP_LDIF_DIR;
-        };
-        ldif_file = format("%s/static-file-all-CE-pbs.ldif\n",static_ldif_dir);
-        ldif_file_glue2 = format("%s/%s\n",static_ldif_dir,GIP_CE_GLUE2_LDIF_FILES['shares']);
-        contents =
-          "[Main]\n" +
-          "static_ldif_file: "+ ldif_file +
-          "static_glue2_ldif_file_computingshare: "+ldif_file_glue2 +
-          "vomap : \n";
-
-        foreach (k; vo; GIP_CE_VOMAP) {
-          contents = contents + "  " + k + ":" + vo + "\n";
-        };
-
-        contents = contents +
-          "module_search_path : ../lrms:../ett\n" +
-          "[LRMS]\n" +
-          "lrms_backend_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-pbs\n" +
-          "[Scheduler]\n" +
-          "cycle_time : 0\n" +
-          "vo_max_jobs_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/vomaxjobs-maui\n";
-
-      } else if ( lrms == "condor" ) {
-        contents =
-          "[Main]\n" +
-          "static_ldif_file: " + GIP_LDIF_DIR + "/static-file-all-CE-"+lrms+".ldif\n" +
-          "vomap : \n";
-
-        foreach (k; vo; GIP_CE_VOMAP) {
-          contents = contents + "  " + k + ":" + vo + "\n";
-        };
-
-        contents = contents +
-          "module_search_path : ../lrms:../ett\n" +
-          "[LRMS]\n" +
-          "lrms_backend_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-condor\n" +
-          "[Scheduler]\n" +
-          "cycle_time : 0\n";
-      };
-
-      SELF[escape(GIP_SCRIPTS_CONF_DIR+'/lcg-info-dynamic-scheduler-'+lrms+'.conf')] = contents;
+    if ( is_defined(SELF) && !is_dict(SELF) ) {
+        error('/software/components/gip2/scripts must be an dict');
     };
-  };
 
-  SELF;
+    # iterate over supported batch systems
+    if ( is_defined(CE_BATCH_SYS_LIST) ) {
+        foreach (jobmanager;lrms;CE_BATCH_SYS_LIST) {
+            if ( lrms == "pbs" ) {
+                if ( GIP_CE_USE_CACHE ) {
+                    static_ldif_dir = GIP_VAR_DIR;
+                } else {
+                    static_ldif_dir = GIP_LDIF_DIR;
+                };
+                ldif_file = format("%s/static-file-all-CE-pbs.ldif\n", static_ldif_dir);
+                ldif_file_glue2 = format("%s/%s\n", static_ldif_dir, GIP_CE_GLUE2_LDIF_FILES['shares']);
+                contents = "[Main]\n" + "static_ldif_file: "+ ldif_file +
+                            "static_glue2_ldif_file_computingshare: "+ldif_file_glue2 +
+                            "vomap : \n";
+   
+                foreach (k; vo; GIP_CE_VOMAP) {
+                    contents = contents + "  " + k + ":" + vo + "\n";
+                };
+     
+                contents = contents + 
+                            "module_search_path : ../lrms:../ett\n" + 
+                            "[LRMS]\n" + 
+                            "lrms_backend_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-pbs\n" + 
+                            "[Scheduler]\n" + 
+                            "cycle_time : 0\n" + 
+                            "vo_max_jobs_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/vomaxjobs-maui\n";
+  
+            } else if ( lrms == "condor" ) {
+                contents = "[Main]\n" + 
+                             "static_ldif_file: " + GIP_LDIF_DIR + "/static-file-all-CE-"+lrms+".ldif\n" + 
+                             "vomap : \n";
+   
+                foreach (k; vo; GIP_CE_VOMAP) {
+                    contents = contents + "  " + k + ":" + vo + "\n";
+                };
+  
+                contents = contents + 
+                    "module_search_path : ../lrms:../ett\n" + 
+                    "[LRMS]\n" + 
+                    "lrms_backend_cmd: "+ LCG_INFO_SCRIPTS_DIR + "/lrmsinfo-condor\n" + 
+                    "[Scheduler]\n" + 
+                    "cycle_time : 0\n";
+            };
+      
+            SELF[escape(GIP_SCRIPTS_CONF_DIR+'/lcg-info-dynamic-scheduler-'+lrms+'.conf')] = contents;
+        };
+    };
+  
+    SELF;
 };
 
 # Plugin for software tags.
@@ -573,538 +595,560 @@ variable GIP_CE_VOMAP ?= {
 # ---------------------------------------------------------------------
 
 # MPI-related SW tags
-include { if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) 'features/gip/mpi' };
+include if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) 'features/gip/mpi';
 
 variable GIP_CE_LDIF_PARAMS = {
 
-  # Glue cluster and subcluster information.
-  # Added only if the current host is the LRMS host (GIP_CLUSTER_PUBLISHER_HOST
-  # can be redefined to change this behaviour).
-  # Do not create if CE_FLAVOR is undefined (not a CE).
+    # Glue cluster and subcluster information.
+    # Added only if the current host is the LRMS host (GIP_CLUSTER_PUBLISHER_HOST
+    # can be redefined to change this behaviour).
+    # Do not create if CE_FLAVOR is undefined (not a CE).
 
-  if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
-    # Build service endpoint and associated foreign key for each queue based on CE type
-    queue_endpoints = list();
-    foreign_keys = list("GlueSiteUniqueID="+SITE_NAME);
-    foreach (queue;vos;CE_QUEUES['vos']) {
-      if (exists(CE_QUEUES['lrms'][queue])) {
-        jobmanager=CE_QUEUES['lrms'][queue];
-        lrms = CE_BATCH_SYS_LIST[jobmanager];
-      }
-      else {
-        jobmanager=CE_JM_TYPE;
-        lrms = jobmanager;
-      };
-      foreach (i;ce;CE_HOSTS) {
-        if ( index(ce,CE_HOSTS_CREAM) >= 0 ) {
-          ce_flavor = 'cream';
-        } else {
-          error(format('Non CREAM CE found (%s): only CREAM CE are supported',ce));
+    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {    
+        # Build service endpoint and associated foreign key for each queue based on CE type
+        queue_endpoints = list();
+        foreign_keys = list("GlueSiteUniqueID="+SITE_NAME);
+        foreach (queue; vos; CE_QUEUES['vos']) {
+            if (exists(CE_QUEUES['lrms'][queue])) {
+                jobmanager = CE_QUEUES['lrms'][queue];
+                lrms = CE_BATCH_SYS_LIST[jobmanager];
+            } else {
+                jobmanager=CE_JM_TYPE;
+                lrms = jobmanager;
+            };
+            foreach (i; ce; CE_HOSTS) {
+                if ( index(ce,CE_HOSTS_CREAM) >= 0 ) {
+                    ce_flavor = 'cream';
+                } else {
+                    error(format('Non CREAM CE found (%s): only CREAM CE are supported', ce));
+                };
+        
+                if ( ce_flavor == 'cream' ) {
+                    # CREAM CE doesn't know about all LCG CE job manager variants...
+                    jobmanager = lrms;
+                    queue_endpoints[length(queue_endpoints)] = ce + ":" + to_string(CE_PORT[ce_flavor]) +
+                                                                "/cream-" + jobmanager + "-" + queue;
+                    foreign_keys[length(foreign_keys)] = "GlueCEUniqueID=" +ce + ":" + 
+                                                          to_string(CE_PORT[ce_flavor]) + "/cream-" +
+                                                          jobmanager + "-" + queue;
+                } else {
+                    queue_endpoints[length(queue_endpoints)] = ce + ":" + to_string(CE_PORT[ce_flavor]) +
+                                                                "/jobmanager-" + jobmanager + "-" + queue;
+                    foreign_keys[length(foreign_keys)] = "GlueCEUniqueID=" + ce + ":" +
+                                                          to_string(CE_PORT[ce_flavor]) + "/jobmanager-" +
+                                                          jobmanager + "-" + queue;
+                };
+            };
         };
-
-        if ( ce_flavor == 'cream' ) {
-          # CREAM CE doesn't know about all LCG CE job manager variants...
-          jobmanager = lrms;
-          queue_endpoints[length(queue_endpoints)] = ce+":"+to_string(CE_PORT[ce_flavor])+"/cream-"+jobmanager+"-"+queue;
-          foreign_keys[length(foreign_keys)] = "GlueCEUniqueID="+ce+":"+to_string(CE_PORT[ce_flavor])+"/cream-"+jobmanager+"-"+queue;
-        } else {
-          queue_endpoints[length(queue_endpoints)] = ce+":"+to_string(CE_PORT[ce_flavor])+"/jobmanager-"+jobmanager+"-"+queue;
-          foreign_keys[length(foreign_keys)] = "GlueCEUniqueID="+ce+":"+to_string(CE_PORT[ce_flavor])+"/jobmanager-"+jobmanager+"-"+queue;
-        };
-      };
-    };
-
-    cluster_entries_g1 = nlist();
-    cluster_entries_g1[escape('dn: GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST+',Mds-Vo-name=resource,o=grid')] =
-      nlist(
-            "objectClass",               list('GlueClusterTop','GlueCluster','GlueInformationService','GlueKey','GlueSchemaVersion'),
-            "GlueClusterName",           list(GIP_CLUSTER_PUBLISHER_HOST),
-            "GlueForeignKey",            foreign_keys,
-            "GlueClusterService",        queue_endpoints,
+  
+        cluster_entries_g1 = dict();
+        cluster_entries_g1[escape('dn: GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST + ',Mds-Vo-name=resource,o=grid')] = 
+        dict(
+            "objectClass", list('GlueClusterTop', 'GlueCluster', 'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
+            "GlueClusterName", list(GIP_CLUSTER_PUBLISHER_HOST),
+            "GlueForeignKey", foreign_keys,
+            "GlueClusterService", queue_endpoints,
             "GlueInformationServiceURL", list(RESOURCE_INFORMATION_URL),
-            "GlueSchemaVersionMajor"   , list("1"),
-            "GlueSchemaVersionMinor"   , list("3"),
-           );
+            "GlueSchemaVersionMajor", list("1"),
+            "GlueSchemaVersionMinor", list("3"),
+        );
+  
+        # For GlueHostArchitecturePlatformType, assume the same type as CE until we support several subclusters
+        # per cluster.
+        average_core_num = to_double(CE_CPU_CONFIG['slots']) / CE_CPU_CONFIG['cpus'];
+        hepspec06 = 4 * to_double(CE_SI00) / 1000;
 
-    # For GlueHostArchitecturePlatformType, assume the same type as CE until we support several subclusters
-    # per cluster.
-    average_core_num = to_double(CE_CPU_CONFIG['slots']) / CE_CPU_CONFIG['cpus'];
-    hepspec06 = 4 * to_double(CE_SI00) / 1000;
-    cluster_entries_g1[escape('dn: GlueSubClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST+', GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST+',Mds-Vo-name=resource,o=grid')] =
-      nlist(
-            'objectClass',                      list('GlueClusterTop','GlueSubCluster','GlueHostApplicationSoftware','GlueHostArchitecture',
-                                                     'GlueHostBenchmark','GlueHostMainMemory','GlueHostOperatingSystem','GlueHostProcessor',
-                                                     'GlueInformationService','GlueKey','GlueSchemaVersion'),
-            'GlueSubClusterUniqueID',           list(GIP_CLUSTER_PUBLISHER_HOST),
-            'GlueChunkKey',                     list('GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST),
-            'GlueHostArchitectureSMPSize',      list(CE_SMPSIZE),
+        cluster_entries_g1[escape('dn: GlueSubClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST +
+                                   ', GlueClusterUniqueID=' + GIP_CLUSTER_PUBLISHER_HOST +
+                                   ',Mds-Vo-name=resource,o=grid')] = 
+        dict(
+            'objectClass', list('GlueClusterTop', 'GlueSubCluster', 'GlueHostApplicationSoftware', 'GlueHostArchitecture',
+                                 'GlueHostBenchmark', 'GlueHostMainMemory', 'GlueHostOperatingSystem', 'GlueHostProcessor',
+                                 'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
+            'GlueSubClusterUniqueID', list(GIP_CLUSTER_PUBLISHER_HOST),
+            'GlueChunkKey', list('GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST),
+            'GlueHostArchitectureSMPSize', list(CE_SMPSIZE),
             'GlueHostArchitecturePlatformType', list(CE_WN_ARCH),
-            'GlueHostBenchmarkSF00',            list(CE_SF00),
-            'GlueHostBenchmarkSI00',            list(CE_SI00),
-            'GlueHostMainMemoryRAMSize',        list(CE_MINPHYSMEM),
-            'GlueHostMainMemoryVirtualSize',    list(CE_MINVIRTMEM),
-            'GlueHostNetworkAdapterInboundIP',  list(CE_INBOUNDIP),
+            'GlueHostBenchmarkSF00', list(CE_SF00),
+            'GlueHostBenchmarkSI00', list(CE_SI00),
+            'GlueHostMainMemoryRAMSize', list(CE_MINPHYSMEM),
+            'GlueHostMainMemoryVirtualSize', list(CE_MINVIRTMEM),
+            'GlueHostNetworkAdapterInboundIP', list(CE_INBOUNDIP),
             'GlueHostNetworkAdapterOutboundIP', list(CE_OUTBOUNDIP),
-            'GlueHostOperatingSystemName',      list(CE_OS),
-            'GlueHostOperatingSystemRelease',   list(CE_OS_RELEASE),
-            'GlueHostOperatingSystemVersion',   list(CE_OS_VERSION),
-            'GlueHostProcessorClockSpeed',      list(CE_CPU_SPEED),
-            'GlueHostProcessorModel',           list(CE_CPU_MODEL),
-            'GlueHostProcessorOtherDescription', list('Cores='+to_string(average_core_num)+
-                                                      ',Benchmark='+to_string(hepspec06)+'-HEP-SPEC06'),
-            'GlueHostProcessorVendor',          list(CE_CPU_VENDOR),
-            'GlueSubClusterName',               list(FULL_HOSTNAME),
-            'GlueSubClusterPhysicalCPUs',       list(to_string(CE_CPU_CONFIG['cpus'])),
-            'GlueSubClusterLogicalCPUs',        list(to_string(CE_CPU_CONFIG['slots'])),
-            'GlueSubClusterTmpDir',             list('/tmp'),
-            'GlueSubClusterWNTmpDir',           list('/tmp'),
+            'GlueHostOperatingSystemName', list(CE_OS),
+            'GlueHostOperatingSystemRelease', list(CE_OS_RELEASE),
+            'GlueHostOperatingSystemVersion', list(CE_OS_VERSION),
+            'GlueHostProcessorClockSpeed', list(CE_CPU_SPEED),
+            'GlueHostProcessorModel', list(CE_CPU_MODEL),
+            'GlueHostProcessorOtherDescription', list('Cores='+ to_string(average_core_num) +
+                                                      ',Benchmark=' + to_string(hepspec06) + '-HEP-SPEC06'),
+            'GlueHostProcessorVendor', list(CE_CPU_VENDOR),
+            'GlueSubClusterName', list(FULL_HOSTNAME),
+            'GlueSubClusterPhysicalCPUs', list(to_string(CE_CPU_CONFIG['cpus'])),
+            'GlueSubClusterLogicalCPUs', list(to_string(CE_CPU_CONFIG['slots'])),
+            'GlueSubClusterTmpDir', list('/tmp'),
+            'GlueSubClusterWNTmpDir', list('/tmp'),
             "GlueInformationServiceURL", list(RESOURCE_INFORMATION_URL),
             'GlueHostApplicationSoftwareRunTimeEnvironment', CE_RUNTIMEENV,
-            'GlueSchemaVersionMajor',           list("1"),
-            'GlueSchemaVersionMinor',           list("3"),
-            );
+            'GlueSchemaVersionMajor', list("1"),
+            'GlueSchemaVersionMinor', list("3"),
+        );
 
-    SELF["glue1"]["lcg-info-static-cluster.conf"]['ldifFile'] = "static-file-Cluster.ldif";
-    SELF["glue1"]["lcg-info-static-cluster.conf"]['entries'] = cluster_entries_g1;
-  };
+        SELF["glue1"]["lcg-info-static-cluster.conf"]['ldifFile'] = "static-file-Cluster.ldif";
+        SELF["glue1"]["lcg-info-static-cluster.conf"]['entries'] = cluster_entries_g1;
+    };
+  
 
-
-  # Glue CE static information.
-  # When using GIP in cache mode and the current node is the LRMS
-  # server, a second LDIF file is produced with the entries for all
-  # CEs to be used as input by GIP plugin run in cache mode on the LRMS server.
-  # All CEs are assumed to share the same configuration for queue state, default SE...
-  # Cache mode is currently supported only for Torque/MAUI.
-  # iterate over all defined queues (there is one GlueCE object per queue)
-  if ( is_defined(CE_QUEUES['vos']) ) {
-    # GLUE1: host_entries_g1 and all_ce_entries_g1 contain the VOView/CE DN list per LRMS
-    # GLUE2: all_ce_entries_g2 contain the shares and computing service descriptions (there is no host_entries_g2)
-    host_entries_g1 = nlist();
-    all_ce_entries_g1 = nlist();
-    share_entries_g2 = nlist();
-
-    foreach (queue;vos;CE_QUEUES['vos']) {
-      if (exists(CE_QUEUES['lrms'][queue])) {
-        jobmanager=CE_QUEUES['lrms'][queue];
-      }
-      else {
-        jobmanager=CE_BATCH_SYS;
-      };
-      lrms = CE_BATCH_SYS_LIST[jobmanager];
-      if ( !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
-      # FIXME: when lcg-info-dynamic-scheduler is fixed to allow publishing GlueCE/GlueVOView on the CE,
-      # uncomment next line and remove the following one (initialize host_entries_g1[lrms] only if
-      # GIP_CE_USE_CACHE is true).
-      #if ( GIP_CE_USE_CACHE && !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
-      if ( !is_nlist(host_entries_g1[lrms]) ) host_entries_g1[lrms] = nlist();
-
-      # FIXME: cache mode should not be specific to Torque/MAUI...
-      # FIXME: cluster mode (distinct CEs and LRMS master) validation with LRMS other than Torque/MAUI
-      if ( FULL_HOSTNAME == LRMS_SERVER_HOST ) {
-        ce_list = CE_HOSTS;
-        # Create only if necessary to avoid creating a useless emtpy file
-        # FIXME: when lcg-info-dynamic-scheduler is fixed to allow publishing GlueCE/GlueVOView on the CE,
-        #        initialize all_ce_entries_g1[lrms] only if GIP_CE_USE_CACHE is true.
-        #        Also see the related modification at the end of this block.
-        #        Issue can be followed up at https://ggus.eu/index.php?mode=ticket_info&ticket_id=110336.
-        if ( !is_nlist(all_ce_entries_g1[lrms]) ) all_ce_entries_g1[lrms] = nlist();
-        if ( !is_nlist(share_entries_g2[lrms]) ) share_entries_g2[lrms] = nlist();
-      } else {
-        ce_list = list(FULL_HOSTNAME);
-      };
-
-      foreach (i;ce;ce_list) {
-        if ( index(ce,CE_HOSTS_LCG) >= 0 ) {
-          ce_flavor = 'lcg';
-          unique_id = ce+':'+to_string(CE_PORT[ce_flavor])+'/jobmanager-'+jobmanager+'-'+queue;
-        } else {
-          ce_flavor = 'cream';
-          # On CREAM CE, there is no distinction between lcgpbs and pbs. Reset jobmanager to lrms.
-          jobmanager = lrms;
-          unique_id = ce+':'+to_string(CE_PORT[ce_flavor])+'/cream-'+jobmanager+'-'+queue;
-        };
-
-        access = list();
-        contact = list();
-
-        # Try to set up initial GlueCEStateStatus according to defined
-        # queue state, else assume default. Assume the same state on all CEs.
-        # Will be updated by GIP to reflect the exact status.
-        if ( exists('/software/components/pbsserver/queue/queuelist') ) {
-          queuelist = value('/software/components/pbsserver/queue/queuelist');
-          if ( is_defined(queuelist[queue]['attlist']['enabled']) &&
-               is_defined(queuelist[queue]['attlist']['started']) ) {
-            if ( queuelist[queue]['attlist']['enabled'] && queuelist[queue]['attlist']['started'] ) {
-              queue_status = 'Production';
-            } else if ( queuelist[queue]['attlist']['enabled'] && !queuelist[queue]['attlist']['started'] ) {
-              queue_status = 'Queueing';
-            } else if ( queuelist[queue]['attlist']['started'] && !queuelist[queue]['attlist']['enabled'] ) {
-              queue_status = 'Draining';
+    # Glue CE static information.
+    # When using GIP in cache mode and the current node is the LRMS
+    # server, a second LDIF file is produced with the entries for all
+    # CEs to be used as input by GIP plugin run in cache mode on the LRMS server.
+    # All CEs are assumed to share the same configuration for queue state, default SE...
+    # Cache mode is currently supported only for Torque/MAUI.
+    # iterate over all defined queues (there is one GlueCE object per queue)
+    if ( is_defined(CE_QUEUES['vos']) ) {
+        # GLUE1: host_entries_g1 and all_ce_entries_g1 contain the VOView/CE DN list per LRMS
+        # GLUE2: all_ce_entries_g2 contain the shares and computing service descriptions (there is no host_entries_g2)
+        host_entries_g1 = dict();
+        all_ce_entries_g1 = dict();
+        share_entries_g2 = dict();
+    
+        foreach (queue; vos; CE_QUEUES['vos']) {
+            if (exists(CE_QUEUES['lrms'][queue])) {
+                jobmanager = CE_QUEUES['lrms'][queue];
             } else {
-              queue_status = 'Closed';
+                jobmanager=CE_BATCH_SYS;
             };
-          } else {
-            queue_status = CE_STATUS;
-          };
-        } else {
-          queue_status = CE_STATUS;
-        };
-
-        entries_g1 = nlist();
-        entries_g2 = nlist();
-        foreach (k;vo;vos) {
-          vo_name = VO_INFO[vo]['name'];
-          rule = "VO:"+ vo_name;
-          access[length(access)] = rule;
-
-          if ( is_defined(CE_DEFAULT_SE) ) {
-            gluese_info_default_se = nlist('GlueCEInfoDefaultSE', list(CE_DEFAULT_SE));
-          } else {
-            gluese_info_default_se = nlist();
-          };
-
-          if ( is_defined(CE_VO_DEFAULT_SE[vo]) ) {
-            gluese_info_default_se = nlist('GlueCEInfoDefaultSE', list(CE_VO_DEFAULT_SE[vo]));
-          };
-
-          if ( is_defined(VO_INFO[vo]['swarea']['name']) ) {
-            sw_area = nlist('GlueCEInfoApplicationDir', list(VO_INFO[vo]['swarea']['name']));
-          } else {
-            sw_area = nlist();
-          };
-
-          #FIXME: use home directory if in a shared area
-          shared_data_dir = nlist('GlueCEInfoDataDir', list(CE_DATADIR));
-
-          # GLUE1 GlueVOView entry (LDIF, 1/VO/CE)
-          entries_g1[escape('dn: GlueVOViewLocalID='+vo_name+',GlueCEUniqueID='+unique_id+',Mds-Vo-name=resource,o=grid')] =
-                  merge(nlist('objectClass', list('GlueCETop','GlueVOView','GlueCEInfo','GlueCEState','GlueCEAccessControlBase','GlueCEPolicy',
-                                                  'GlueKey','GlueSchemaVersion'),
-                              'GlueVOViewLocalID',                list(vo_name),
-                              'GlueSchemaVersionMajor',           list('1'),
-                              'GlueSchemaVersionMinor',           list('3'),
-                              'GlueCEAccessControlBaseRule',      list(rule),
-                              'GlueCEStateRunningJobs',           list('0'),
-                              'GlueCEStateWaitingJobs',           list(to_string(GLUE_FAKE_JOB_VALUE)),
-                              'GlueCEStateTotalJobs',             list('0'),
-                              'GlueCEStateFreeJobSlots',          list('0'),
-                              'GlueCEStateEstimatedResponseTime', list('2146660842'),
-                              'GlueCEStateWorstResponseTime',     list('2146660842'),
-                              'GlueChunkKey',                     list("GlueCEUniqueID="+unique_id),
-                             ),
+            lrms = CE_BATCH_SYS_LIST[jobmanager];
+            if ( !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
+            # FIXME: when lcg-info-dynamic-scheduler is fixed to allow publishing GlueCE/GlueVOView on the CE,
+            # uncomment next line and remove the following one (initialize host_entries_g1[lrms] only if
+            # GIP_CE_USE_CACHE is true).
+            #if ( GIP_CE_USE_CACHE && !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
+            if ( !is_dict(host_entries_g1[lrms]) ) host_entries_g1[lrms] = dict();
+   
+            # FIXME: cache mode should not be specific to Torque/MAUI...
+            # FIXME: cluster mode (distinct CEs and LRMS master) validation with LRMS other than Torque/MAUI 
+            if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) { ##Changed LRMS_SERVER_HOST->GIP_CLUSTER_PUBLISHER_HOST
+                ce_list = CE_HOSTS;
+                # Create only if necessary to avoid creating a useless emtpy file
+                # FIXME: when lcg-info-dynamic-scheduler is fixed to allow publishing GlueCE/GlueVOView on the CE,
+                #        initialize all_ce_entries_g1[lrms] only if GIP_CE_USE_CACHE is true.
+                #        Also see the related modification at the end of this block.
+                #        Issue can be followed up at https://ggus.eu/index.php?mode=ticket_info&ticket_id=110336.
+                if ( !is_dict(all_ce_entries_g1[lrms]) ) all_ce_entries_g1[lrms] = dict();
+                if ( !is_dict(share_entries_g2[lrms]) ) share_entries_g2[lrms] = dict();
+            } else {
+                ce_list = list(FULL_HOSTNAME);
+            };
+      
+            foreach (i;ce;ce_list) {
+                if ( index(ce,CE_HOSTS_LCG) >= 0 ) {
+                    ce_flavor = 'lcg';
+                    unique_id = ce + ':' + to_string(CE_PORT[ce_flavor]) + '/jobmanager-' + jobmanager + '-' + queue;
+                } else {
+                    ce_flavor = 'cream';
+                    # On CREAM CE, there is no distinction between lcgpbs and pbs. Reset jobmanager to lrms.
+                    jobmanager = lrms;
+                    unique_id = ce + ':' + to_string(CE_PORT[ce_flavor]) + '/cream-' + jobmanager + '-' + queue;
+                };
+        
+                access = list();
+                contact = list();
+  
+                # Try to set up initial GlueCEStateStatus according to defined
+                # queue state, else assume default. Assume the same state on all CEs.
+                # Will be updated by GIP to reflect the exact status.
+                if ( exists('/software/components/pbsserver/queue/queuelist') ) {
+                    queuelist = value('/software/components/pbsserver/queue/queuelist');
+                    if ( is_defined(queuelist[queue]['attlist']['enabled']) &&
+                         is_defined(queuelist[queue]['attlist']['started']) ) {
+                        if ( queuelist[queue]['attlist']['enabled'] && queuelist[queue]['attlist']['started'] ) {
+                            queue_status = 'Production';
+                        } else if ( queuelist[queue]['attlist']['enabled'] && !queuelist[queue]['attlist']['started'] ) {
+                            queue_status = 'Queueing';
+                        } else if ( queuelist[queue]['attlist']['started'] && !queuelist[queue]['attlist']['enabled'] ) {
+                            queue_status = 'Draining';
+                        } else {
+                            queue_status = 'Closed';
+                        };
+                    } else {
+                        queue_status = CE_STATUS;
+                    };
+                } else {
+                    queue_status = CE_STATUS;
+                };
+  
+                entries_g1 = dict();
+                entries_g2 = dict();
+                foreach (k; vo; vos) {
+                    vo_name = VO_INFO[vo]['name'];
+                    rule = "VO:" + vo_name;
+                    access[length(access)] = rule;
+  
+                    if ( is_defined(CE_DEFAULT_SE) ) {
+                        gluese_info_default_se = dict('GlueCEInfoDefaultSE', list(CE_DEFAULT_SE));
+                    } else {
+                        gluese_info_default_se = dict();
+                    };
+          
+                    if ( is_defined(CE_VO_DEFAULT_SE[vo]) ) {
+                        gluese_info_default_se = dict('GlueCEInfoDefaultSE', list(CE_VO_DEFAULT_SE[vo]));
+                    };
+  
+                    if ( is_defined(VO_INFO[vo]['swarea']['name']) ) {
+                        sw_area = dict('GlueCEInfoApplicationDir', list(VO_INFO[vo]['swarea']['name']));
+                    } else {
+                        sw_area = dict();
+                    };
+  
+                    #FIXME: use home directory if in a shared area
+                    shared_data_dir = dict('GlueCEInfoDataDir', list(CE_DATADIR));
+          
+                    # GLUE1 GlueVOView entry (LDIF, 1/VO/CE)
+                    entries_g1[escape('dn: GlueVOViewLocalID=' + vo_name + ',GlueCEUniqueID=' +
+                                unique_id + ',Mds-Vo-name=resource,o=grid')] = merge(
+                        dict(
+                            'objectClass', list('GlueCETop', 'GlueVOView', 'GlueCEInfo', 'GlueCEState',
+                                                 'GlueCEAccessControlBase', 'GlueCEPolicy',
+                                                 'GlueKey', 'GlueSchemaVersion'),
+                            'GlueVOViewLocalID', list(vo_name),
+                            'GlueSchemaVersionMajor', list('1'),
+                            'GlueSchemaVersionMinor', list('3'),
+                            'GlueCEAccessControlBaseRule', list(rule),
+                            'GlueCEStateRunningJobs', list('0'),
+                            'GlueCEStateWaitingJobs', list(to_string(GLUE_FAKE_JOB_VALUE)),
+                            'GlueCEStateTotalJobs', list('0'),
+                            'GlueCEStateFreeJobSlots', list('0'),
+                            'GlueCEStateEstimatedResponseTime', list('2146660842'),
+                            'GlueCEStateWorstResponseTime', list('2146660842'),
+                            'GlueChunkKey', list("GlueCEUniqueID="+unique_id),
+                        ),
                         gluese_info_default_se,
                         sw_area,
                         shared_data_dir,
-                       );
-        };
+                    );
+                };
+    
+                # GLUE1 GlueCE entry (LDIF)
+                entries_g1[escape('dn: GlueCEUniqueID=' + unique_id + ',Mds-Vo-name=resource,o=grid')] = merge(
+                    dict(
+                        'objectClass', list('GlueCETop', 'GlueCE', 'GlueCEAccessControlBase',
+                                             'GlueCEInfo', 'GlueCEPolicy', 'GlueCEState',
+                                             'GlueInformationService', 'GlueKey', 'GlueSchemaVersion'),
+                        'GlueCEImplementationName', list(GLUE_CE_IMPLEMENTATION[ce_flavor]),
+                        'GlueCEImplementationVersion', list(CREAM_CE_VERSION),
+                        'GlueCEHostingCluster', list(GIP_CLUSTER_PUBLISHER_HOST),
+                        'GlueCEName', list(queue),
+                        'GlueCEUniqueID', list(unique_id),
+                        'GlueCEInfoGatekeeperPort', list(to_string(CE_PORT[ce_flavor])),
+                        # This is a hack to fix a problem affecting WMS/NagiosBox that don't like a InfoHostName
+                        # that doesn't match a CE name... InfoHostName should be FULL_HOSTNAME normally. 
+                        'GlueCEInfoHostName', list(ce),
+                        'GlueCEInfoLRMSType', list(lrms),
+                        'GlueCEInfoLRMSVersion', list('not defined'),
+                        'GlueCEInfoTotalCPUs', list('0'),
+                        'GlueCEInfoJobManager', list(jobmanager),
+                        'GlueCEInfoContactString', list(unique_id),
+                        'GlueCEInfoApplicationDir', list("/home/"),
+                        'GlueCEInfoDataDir', list(CE_DATADIR),
+                        'GlueCEStateEstimatedResponseTime', list(to_string(2146660842)),
+                        'GlueCEStateFreeCPUs', list('0'),
+                        'GlueCEStateRunningJobs', list('0'),
+                        'GlueCEStateStatus', list(queue_status),
+                        'GlueCEStateTotalJobs', list('0'),
+                        'GlueCEStateWaitingJobs', list(to_string(GLUE_FAKE_JOB_VALUE)),
+                        'GlueCEStateWorstResponseTime', list('2146660842'),
+                        'GlueCEStateFreeJobSlots', list('0'),
+                        'GlueCEPolicyMaxCPUTime', list('0'),
+                        'GlueCEPolicyMaxRunningJobs', list('0'),
+                        'GlueCEPolicyMaxTotalJobs', list('0'),
+                        'GlueCEPolicyMaxWallClockTime', list('0'),
+                        'GlueCEPolicyPriority', list('1'),
+                        'GlueCEPolicyAssignedJobSlots', list('0'),
+                        'GlueCECapability', CE_CAPABILITIES,
+                        'GlueForeignKey', list('GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST),
+                        'GlueInformationServiceURL', list(RESOURCE_INFORMATION_URL),
+                        'GlueCEAccessControlBaseRule', access,
+                        'GlueCEPolicyMaxObtainableCPUTime', list('0'),
+                        'GlueCEPolicyMaxObtainableWallClockTime', list('0'),
+                        'GlueCEPolicyMaxSlotsPerJob', list('0'),
+                        'GlueCEPolicyPreemption', list('0'),
+                        'GlueCEPolicyMaxWaitingJobs', list('0'),
+                        'GlueSchemaVersionMajor', list('1'),
+                        'GlueSchemaVersionMinor', list('3'),
+                    ),
+                    gluese_info_default_se
+                );
 
-        # GLUE1 GlueCE entry (LDIF)
-        entries_g1[escape('dn: GlueCEUniqueID='+unique_id+',Mds-Vo-name=resource,o=grid')] =
-                merge(nlist('objectClass',              list('GlueCETop','GlueCE','GlueCEAccessControlBase','GlueCEInfo','GlueCEPolicy', 'GlueCEState',
-                                                             'GlueInformationService','GlueKey','GlueSchemaVersion'),
-                            'GlueCEImplementationName',    list(GLUE_CE_IMPLEMENTATION[ce_flavor]),
-                            'GlueCEImplementationVersion', list(CREAM_CE_VERSION),
-                            'GlueCEHostingCluster',        list(GIP_CLUSTER_PUBLISHER_HOST),
-                            'GlueCEName',                  list(queue),
-                            'GlueCEUniqueID',              list(unique_id),
-                            'GlueCEInfoGatekeeperPort',    list(to_string(CE_PORT[ce_flavor])),
-                            # This is a hack to fix a problem affecting WMS/NagiosBox that don't like a InfoHostName
-                            # that doesn't match a CE name... InfoHostName should be FULL_HOSTNAME normally.
-                            'GlueCEInfoHostName',          list(ce),
-                            'GlueCEInfoLRMSType',          list(lrms),
-                            'GlueCEInfoLRMSVersion',       list('not defined'),
-                            'GlueCEInfoTotalCPUs',         list('0'),
-                            'GlueCEInfoJobManager',        list(jobmanager),
-                            'GlueCEInfoContactString',     list(unique_id),
-                            'GlueCEInfoApplicationDir',         list("/home/"),
-                            'GlueCEInfoDataDir',                list(CE_DATADIR),
-                            'GlueCEStateEstimatedResponseTime', list(to_string(2146660842)),
-                            'GlueCEStateFreeCPUs', list('0'),
-                            'GlueCEStateRunningJobs', list('0'),
-                            'GlueCEStateStatus', list(queue_status),
-                            'GlueCEStateTotalJobs', list('0'),
-                            'GlueCEStateWaitingJobs', list(to_string(GLUE_FAKE_JOB_VALUE)),
-                            'GlueCEStateWorstResponseTime', list('2146660842'),
-                            'GlueCEStateFreeJobSlots', list('0'),
-                            'GlueCEPolicyMaxCPUTime', list('0'),
-                            'GlueCEPolicyMaxRunningJobs', list('0'),
-                            'GlueCEPolicyMaxTotalJobs', list('0'),
-                            'GlueCEPolicyMaxWallClockTime', list('0'),
-                            'GlueCEPolicyPriority', list('1'),
-                            'GlueCEPolicyAssignedJobSlots', list('0'),
-                            'GlueCECapability', CE_CAPABILITIES,
-                            'GlueForeignKey', list('GlueClusterUniqueID='+GIP_CLUSTER_PUBLISHER_HOST),
-                            'GlueInformationServiceURL', list(RESOURCE_INFORMATION_URL),
-                            'GlueCEAccessControlBaseRule', access,
-                            'GlueCEPolicyMaxObtainableCPUTime', list('0'),
-                            'GlueCEPolicyMaxObtainableWallClockTime', list('0'),
-                            'GlueCEPolicyMaxSlotsPerJob', list('0'),
-                            'GlueCEPolicyPreemption', list('0'),
-                            'GlueCEPolicyMaxWaitingJobs', list('0'),
-                            'GlueSchemaVersionMajor',     list('1'),
-                            'GlueSchemaVersionMinor',     list('3'),
-                           ),
-                      gluese_info_default_se
-                     );
+                # Entries are for the current host, add them to the list of DN for the GIP standard LDIF file
+                if ( ce == FULL_HOSTNAME ) {
+                    host_entries_g1[lrms] = merge(host_entries_g1[lrms], entries_g1);
+                };
+        
+                # Also add to GLUE1 LDIF file used when cache mode is enabled (several entries in ce_list)
+                if ( is_dict(all_ce_entries_g1[lrms]) ) {
+                    all_ce_entries_g1[lrms] = merge(all_ce_entries_g1[lrms], entries_g1);
+                };
 
-        # Entries are for the current host, add them to the list of DN for the GIP standard LDIF file
-        if ( ce == FULL_HOSTNAME ) {
-          host_entries_g1[lrms] = merge(host_entries_g1[lrms],entries_g1);
-        };
+                foreach (k; vo; vos) {
+                    vo_name = VO_INFO[vo]['name'];
+                    # GLUE2 entry (LDIF generator config entry).
+	            if(!is_defined(GLUE2_SHARES_BY_CE)||!GLUE2_SHARES_BY_CE){
+                        # GLUE2 shares are independent of CEs: add only once.
+                        share_name =  replace('\.', '-', format('%s_%s', queue, vo_name));
+                    }else{
+	                # GLUE2 shares are different by CEs as queues depends on the CEs
+	                share_name =  replace('\.', '-', format('%s_%s_%s', ce, queue, vo_name));
+	            };
+                    if ( !is_defined(share_entries_g2[lrms][share_name]) ) {
+                        glue2_var_prefix = format('SHARE_%s_', to_uppercase(share_name));
+                        entries_g2[share_name] = dict(
+                            glue2_var_prefix + 'QUEUENAME', list(queue),
+                            glue2_var_prefix + 'OWNER', list(vo_name),
+                            glue2_var_prefix + 'ENDPOINTS', list(ce + '_org.glite.ce.CREAM'),
+                            glue2_var_prefix + 'EXECUTIONENVIRONMENTS', list(GIP_CLUSTER_PUBLISHER_HOST),
+                            glue2_var_prefix + 'ACBRS', access,
+                            glue2_var_prefix + 'CEIDS', list(unique_id),
+                        );
+                    };
+                };
 
-        # Also add to GLUE1 LDIF file used when cache mode is enabled (several entries in ce_list)
-        if ( is_nlist(all_ce_entries_g1[lrms]) ) {
-          all_ce_entries_g1[lrms] = merge(all_ce_entries_g1[lrms],entries_g1);
-        };
+                # GLUE2 : add entries if on the LRMS master node
+                if ( is_dict(share_entries_g2[lrms]) ) {
+                    share_entries_g2[lrms] = merge(share_entries_g2[lrms],entries_g2);
+                };
 
-        foreach (k;vo;vos) {
-          vo_name = VO_INFO[vo]['name'];
-          # GLUE2 entry (LDIF generator config entry).
-          # GLUE2 shares are independent of CEs: add only once.
-          share_name =  replace('\.','-',format('%s_%s',queue,vo_name));
-          if ( !is_defined(share_entries_g2[lrms][share_name]) ) {
-            glue2_var_prefix = format('SHARE_%s_',to_uppercase(share_name));
-            entries_g2[share_name] = dict(
-                                       glue2_var_prefix+'QUEUENAME', list(queue),
-                                       glue2_var_prefix+'OWNER', list(vo_name),
-                                       glue2_var_prefix+'ENDPOINTS', list(ce+'_org.glite.ce.CREAM'),
-                                       glue2_var_prefix+'EXECUTIONENVIRONMENTS', list(GIP_CLUSTER_PUBLISHER_HOST),
-                                       glue2_var_prefix+'ACBRS', access,
-                                       glue2_var_prefix+'CEIDS', list(unique_id),
-                                     );
-          };
-        };
-
-        # GLUE2 : add entries if on the LRMS master node
-        if ( is_dict(share_entries_g2[lrms]) ) {
-          share_entries_g2[lrms] = merge(share_entries_g2[lrms],entries_g2);
-        };
-
-
-      };           # end of iteration over CEs
-
-    };             # end of iteration over queues
-
-    # Create LDIF configuration entries describing CE queues (GlueCE and GlueVOView).
-    # FIXME: restore original behaviour when lcg-info-dynamic-scheduler is fixed (https://ggus.eu/index.php?mode=ticket_info&ticket_id=110336).
-    #        See other related section at the beginning of this block.
-    # Due to a problem in lcg-info-dynamic-scheduler not allowing anymore to redefine
-    # the static file location, everything is published on the GIP_CLUSTER_PUBLISHER_HOST as
-    # there is no point to publish the same information twice on different hosts.
+               
+            };           # end of iteration over CEs
+      
+        };             # end of iteration over queues
+                 
+        # Create LDIF configuration entries describing CE queues (GlueCE and GlueVOView).
+        # FIXME: restore original behaviour when lcg-info-dynamic-scheduler is fixed (https://ggus.eu/index.php?mode=ticket_info&ticket_id=110336).
+        #        See other related section at the beginning of this block.
+        # Due to a problem in lcg-info-dynamic-scheduler not allowing anymore to redefine
+        # the static file location, everything is published on the GIP_CLUSTER_PUBLISHER_HOST as
+        # there is no point to publish the same information twice on different hosts.
 #    if ( index(FULL_HOSTNAME,CE_HOSTS) >= 0 ) {
 #      foreach (lrms;ce_entries;host_entries_g1) {
 #        conf_file_g1 = "lcg-info-static-ce-"+lrms+".conf";
 #        SELF['glue1'][conf_file_g1]['ldifFile'] = "static-file-CE-"+lrms+".ldif";
-#        if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) ) SELF['glue1'][conf_file_g1]['entries'] = nlist();
+#        if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) ) SELF['glue1'][conf_file_g1]['entries'] = dict();
 #        SELF['glue1'][conf_file_g1]['entries'] = merge(SELF['glue1'][conf_file_g1]['entries'],ce_entries);
 #      };
 #    } else {
-    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
-      foreach (lrms;ce_entries;all_ce_entries_g1) {
-        conf_file_g1 = "lcg-info-static-all-CE-"+lrms+".conf";
-        # Use standard location for LDIF file until the lcg-info-dynamic-scheduler issue is fixed and
-        # original behaviour can be restored.
-        #SELF['glue1'][conf_file_g1]['ldifFile'] = GIP_VAR_DIR + "/static-file-all-CE-"+lrms+".ldif";
-        SELF['glue1'][conf_file_g1]['ldifFile'] = "static-file-all-CE-"+lrms+".ldif";
-        if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) ) SELF['glue1'][conf_file_g1]['entries'] = nlist();
-        SELF['glue1'][conf_file_g1]['entries'] = merge(SELF['glue1'][conf_file_g1]['entries'],ce_entries);
-      };
+        if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
+            foreach (lrms; ce_entries; all_ce_entries_g1) {
+                conf_file_g1 = "lcg-info-static-all-CE-" + lrms + ".conf";
+                # Use standard location for LDIF file until the lcg-info-dynamic-scheduler issue is fixed and 
+                # original behaviour can be restored.
+                #SELF['glue1'][conf_file_g1]['ldifFile'] = GIP_VAR_DIR + "/static-file-all-CE-"+lrms+".ldif";
+                SELF['glue1'][conf_file_g1]['ldifFile'] = "static-file-all-CE-" + lrms + ".ldif";
+                if ( !is_defined(SELF['glue1'][conf_file_g1]['entries']) ) SELF['glue1'][conf_file_g1]['entries'] = dict();
+                SELF['glue1'][conf_file_g1]['entries'] = merge(SELF['glue1'][conf_file_g1]['entries'], ce_entries);
+            };
+        };
+        foreach (lrms;share_entries;share_entries_g2) {
+            conf_file_g2 = "glite-ce-glue2.conf";
+            if ( !is_defined(SELF['glue2']['shares']) ) SELF['glue2']['shares'] = dict();
+            SELF['glue2']['shares'] = merge(SELF['glue2']['shares'], share_entries);
+        };
     };
-    foreach (lrms;share_entries;share_entries_g2) {
-      conf_file_g2 = "glite-ce-glue2.conf";
-      if ( !is_defined(SELF['glue2']['shares']) ) SELF['glue2']['shares'] = nlist();
-      SELF['glue2']['shares'] = merge(SELF['glue2']['shares'],share_entries);
+     
+      
+    # Glue CE-SE binding static information.
+    # Do not create if CE_FLAVOR is undefined (not a CE).
+
+    if ( is_defined(CE_FLAVOR) ) {
+        # iterate over all defined queues (there is one GlueCE object per queue)
+        if ( is_defined(CE_QUEUES['vos']) ) {
+            close_se_entries_g1 = dict();
+      
+            foreach (queue;vos;CE_QUEUES['vos']) {
+                if (exists(CE_QUEUES['lrms'][queue])) {
+                    jobmanager = CE_QUEUES['lrms'][queue];
+                } else {
+                    jobmanager = CE_BATCH_SYS;
+                };
+                lrms = CE_BATCH_SYS_LIST[jobmanager];
+    
+                if ( CE_FLAVOR == 'cream' ) {
+                    # On CREAM CE, there is no distinction between lcgpbs and pbs. Reset jobmanager to lrms.
+                    jobmanager = lrms;
+                    unique_id = FULL_HOSTNAME + ':' + to_string(CE_PORT[CE_FLAVOR]) +
+                                 '/cream-' + jobmanager + '-' + queue;
+                } else {
+                    unique_id = FULL_HOSTNAME + ':' + to_string(CE_PORT[CE_FLAVOR]) +
+                                 '/jobmanager-' + jobmanager + '-' + queue;
+                };
+          
+                # Compute close SE list for the current queue by doing union of close SE
+                # for all VO authorized to access the queue.
+                # CE_VO_CLOSE_SE contains one entry per VO supported on the CE.
+                se_dict = dict();
+                foreach (i; vo; vos) {
+                    se_list = CE_VO_CLOSE_SE[vo];
+                    if ( is_defined(se_list) ) {
+                        foreach (i; v; se_list) {
+                            se_dict[v] = 1;        # Value is useless
+                        };
+                    };
+                };
+                queue_close_se_list = list();
+                if ( length(se_dict) > 0 ) {
+                    foreach (se; v; se_dict) {
+                        queue_close_se_list[length(queue_close_se_list)] = se;
+                    };
+                };
+    
+                # Define list of SEs usable by this queue
+                if ( length(queue_close_se_list) > 0 ) {
+                    close_se_entries_g1[escape('dn: GlueCESEBindGroupCEUniqueID=' + unique_id +
+                                        ',Mds-Vo-name=resource,o=grid')] = dict(
+                        'objectClass', list('GlueGeneralTop', 'GlueCESEBindGroup', 'GlueSchemaVersion'),
+                        'GlueCESEBindGroupSEUniqueID', queue_close_se_list,
+                        'GlueSchemaVersionMajor', list('1'),
+                        'GlueSchemaVersionMinor', list('3'),
+                    );
+                };
+    
+                # Define a GlueCESEBindSEUniqueID per SE usable from the queue (close SE list).
+                # Some SEs may not be managed locally and thus not be listed into SE_HOSTS.
+                foreach (i; se; queue_close_se_list) {   
+                    if ( exists(SE_HOSTS[se]) ) {
+                        params = SE_HOSTS[se];
+                    } else {
+                        params = undef;
+                    };
+          
+                    if ( exists(params['accessPoint']) && is_defined(params['accessPoint']) ) {
+                        accesspoint = params['accessPoint'];
+                    } else {
+                        if ( params['type'] == 'SE_dpm' ) {
+                            toks = matches(se, '^([\w\-]+\.)(.*)$');
+                            if ( length(toks) != 3 ) {
+                                error('Invalid SE host name (' + se + ')');
+                            };
+                            accesspoint = '/dpm/' + toks[2] + '/home';
+                        } else if ( params['type'] == 'SE_classic' ) {
+                            accesspoint = SE_STORAGE_DIR;
+                        } else {
+                            error('No default value for SE Access Point for host ' + se + ' (type=' + params['type'] + ')');
+                        };
+                    };
+          
+                    close_se_entries_g1[escape('dn: GlueCESEBindSEUniqueID=' + se + ',GlueCESEBindGroupCEUniqueID=' +
+                                                unique_id + ',Mds-Vo-name=resource,o=grid')] = dict(
+                        'objectClass', list('GlueGeneralTop', 'GlueCESEBind', 'GlueSchemaVersion'),
+                        'GlueSchemaVersionMajor', list('1'),
+                        'GlueSchemaVersionMinor', list('3'),
+                        'GlueCESEBindGroupCEUniqueID', list(unique_id),
+                        'GlueCESEBindCEAccesspoint', list(accesspoint),
+                        'GlueCESEBindCEUniqueID', list(unique_id),
+                        'GlueCESEBindMountInfo', list(accesspoint),
+                        'GlueCESEBindWeight', list('0'),
+                    );             
+    
+                };
+            };
+        };
+    
+        SELF["glue1"]["lcg-info-static-cesebind.conf"]['ldifFile'] = "static-file-CESEBind.ldif";
+        SELF["glue1"]["lcg-info-static-cesebind.conf"]['entries'] = close_se_entries_g1;
     };
-  };
+  
 
-
-  # Glue CE-SE binding static information.
-  # Do not create if CE_FLAVOR is undefined (not a CE).
-
-  if ( is_defined(CE_FLAVOR) ) {
-    # iterate over all defined queues (there is one GlueCE object per queue)
-    if ( is_defined(CE_QUEUES['vos']) ) {
-      close_se_entries_g1 = nlist();
-
-      foreach (queue;vos;CE_QUEUES['vos']) {
-        if (exists(CE_QUEUES['lrms'][queue])) {
-          jobmanager=CE_QUEUES['lrms'][queue];
+    # Create LDIF configuration entries for GLUE2 (general parameters)
+    # FIXME: ServingState configuration
+    # FIXME: Argus paramater based on actual config
+    # FIXME: CE_BATCH_VERSION paramater based on actual config
+    # FIXME: CloseSEs: set LocalPath/RemotePath
+    # FIXME: manage ESComputingServiceID and WorkingAreaxxx attributes
+    ce_acbr = list();
+    foreach (i; vo; VOS) {
+        ce_acbr[length(ce_acbr)] = format('VO:%s', vo);
+    };
+    ce_shares = list();
+    foreach (lrms; share_entries; share_entries_g2) {
+        foreach (share; params; share_entries) {
+            ce_shares[length(ce_shares)] = to_uppercase(share);
         }
-        else {
-          jobmanager=CE_BATCH_SYS;
+    };
+    ce_close_ses = list();
+    if ( is_defined(queue_close_se_list) ) {
+        foreach (i; se; queue_close_se_list) {
+            ce_close_ses[length(ce_close_ses)] = format('(%s none none)', se);
         };
-        lrms = CE_BATCH_SYS_LIST[jobmanager];
+    };
+    if ( CE_SHARED_HOMES ) {
+        working_area_shared = 'yes';
+    } else {
+        working_area_shared = 'no';
+    };
+    # FIXME: check what ImplementationVersion and InterfaceVersion should be (CE version or LRMS version)
+    SELF['glue2']['CEParameters'] = dict(
+        'SiteId', list(SITE_NAME),
+        'ComputingServiceId', list(LRMS_PRIMARY_SERVER_HOST + '_ComputingElement'),
+        'NumberOfEndPointType', list('3'),
+        'ImplementationVersion', list(CREAM_CE_VERSION),
+        'InterfaceVersion', list(CREAM_CE_VERSION),
+        'HealthStateHelper', list(GIP_PROVIDER_SUBSERVICE['test']),
+        'ServingState', list('production'),
+        'Owner', VOS,
+        'Argus', list('no'),
+        'EMIES', list('no'),
+        'ACBR', ce_acbr,
+        'Shares', ce_shares,
+        'ExecutionEnvironments', list(GIP_CLUSTER_PUBLISHER_HOST),
+        'CE_BATCH_SYS', list(CE_BATCH_SYS),
+        'BATCH_VERSION', list('0.0.0.0'),
+        'CECapabilities', CE_CAPABILITIES,
+        'CloseSEs', ce_close_ses,
+        'WorkingAreaShared', list(working_area_shared),
+        #'WorkingAreaGuaranteed', list('no'),
+        #'WorkingAreaTotal', list('undefined'),
+        #'WorkingAreaFree', list('undefined'),
+        #'WorkingAreaLifeTime', list('undefined'),
+        #'WorkingAreaMultislotTotal', list('undefined'),
+        #'WorkingAreaMultislotFree', list('undefined'),
+        #'WorkingAreaMultislotLifeTime', list('undefined'),
+        #'ESComputingServiceId', list('undefined'),
+    );
 
-        if ( CE_FLAVOR == 'cream' ) {
-          # On CREAM CE, there is no distinction between lcgpbs and pbs. Reset jobmanager to lrms.
-          jobmanager = lrms;
-          unique_id = FULL_HOSTNAME+':'+to_string(CE_PORT[CE_FLAVOR])+'/cream-'+jobmanager+'-'+queue;
-        } else {
-          unique_id = FULL_HOSTNAME+':'+to_string(CE_PORT[CE_FLAVOR])+'/jobmanager-'+jobmanager+'-'+queue;
-        };
 
-        # Compute close SE list for the current queue by doing union of close SE
-        # for all VO authorized to access the queue.
-        # CE_VO_CLOSE_SE contains one entry per VO supported on the CE.
-        se_nlist = nlist();
-        foreach (i;vo;vos) {
-          se_list = CE_VO_CLOSE_SE[vo];
-          if ( is_defined(se_list) ) {
-            foreach (i;v;se_list) {
-              se_nlist[v] = 1;        # Value is useless
-            };
-          };
-        };
-        queue_close_se_list = list();
-        if ( length(se_nlist) > 0 ) {
-          foreach (se;v;se_nlist) {
-            queue_close_se_list[length(queue_close_se_list)] = se;
-          };
-        };
-
-        # Define list of SEs usable by this queue
-        if ( length(queue_close_se_list) > 0 ) {
-          close_se_entries_g1[escape('dn: GlueCESEBindGroupCEUniqueID='+unique_id+',Mds-Vo-name=resource,o=grid')] =
-                         nlist('objectClass', list('GlueGeneralTop','GlueCESEBindGroup','GlueSchemaVersion'),
-                               'GlueCESEBindGroupSEUniqueID', queue_close_se_list,
-                               'GlueSchemaVersionMajor', list('1'),
-                               'GlueSchemaVersionMinor', list('3'),
-                              );
-        };
-
-        # Define a GlueCESEBindSEUniqueID per SE usable from the queue (close SE list).
-        # Some SEs may not be managed locally and thus not be listed into SE_HOSTS.
-        foreach (i;se;queue_close_se_list) {
-          if ( exists(SE_HOSTS[se]) ) {
-            params = SE_HOSTS[se];
-          } else {
-            params = undef;
-          };
-
-          if ( exists(params['accessPoint']) && is_defined(params['accessPoint']) ) {
-            accesspoint = params['accessPoint'];
-          } else {
-            if ( params['type'] == 'SE_dpm' ) {
-              toks = matches(se, '^([\w\-]+\.)(.*)$');
-              if ( length(toks) != 3 ) {
-                error('Invalid SE host name ('+se+')');
-              };
-              accesspoint = '/dpm/'+toks[2]+'/home';
-            } else if ( params['type'] == 'SE_classic' ) {
-              accesspoint = SE_STORAGE_DIR;
-            } else {
-              error('No default value for SE Access Point for host '+se+' (type='+params['type']+')');
-            };
-          };
-
-          close_se_entries_g1[escape('dn: GlueCESEBindSEUniqueID='+se+',GlueCESEBindGroupCEUniqueID='+unique_id+',Mds-Vo-name=resource,o=grid')] =
-            nlist(
-                 'objectClass', list('GlueGeneralTop','GlueCESEBind','GlueSchemaVersion'),
-                 'GlueSchemaVersionMajor',      list('1'),
-                 'GlueSchemaVersionMinor',      list('3'),
-                 'GlueCESEBindGroupCEUniqueID', list(unique_id),
-                 'GlueCESEBindCEAccesspoint',   list(accesspoint),
-                 'GlueCESEBindCEUniqueID',      list(unique_id),
-                 'GlueCESEBindMountInfo',       list(accesspoint),
-                 'GlueCESEBindWeight',          list('0'),
-                 );
-
-        };
-      };
+    # Create LDIF configuration entries for GLUE2 (execution environment parameters)
+    # FIXME: SmpSize, Cores. Define separate Execution Environments for different HW?
+    # FIXME: ProcessorVendor. Define separate Execution Environments for different HW?
+    # FIXME: ProcessorModel. Define separate Execution Environments for different HW?
+    # FIXME: ProcessorClockSpeed. Define separate Execution Environments for different HW?
+    if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {    
+        glue2_var_prefix = format('ExecutionEnvironment_%s_',GIP_CLUSTER_PUBLISHER_HOST);
+        SELF['glue2']['ExecutionEnvironment'] = dict(
+            glue2_var_prefix + 'ArchitecturePlatformType', list(CE_WN_ARCH),
+            glue2_var_prefix + 'PhysicalCPUs', list(to_string(CE_CPU_CONFIG['cpus'])),
+            glue2_var_prefix + 'LogicalCPUs', list(to_string(CE_CPU_CONFIG['slots'])),
+            glue2_var_prefix + 'SmpSize', list(CE_SMPSIZE),
+            glue2_var_prefix + 'ProcessorVendor', list(CE_CPU_VENDOR),
+            glue2_var_prefix + 'ProcessorModel', list(CE_CPU_MODEL),
+            glue2_var_prefix + 'ProcessorClockSpeed', list(CE_CPU_SPEED),
+            glue2_var_prefix + 'MainMemoryRAMSize', list(CE_MINPHYSMEM),
+            glue2_var_prefix + 'MainMemoryVirtualSize', list(CE_MINVIRTMEM),
+            glue2_var_prefix + 'OperatingSystemFamily', list(CE_OS_FAMILY),
+            glue2_var_prefix + 'OperatingSystemName', list(CE_OS),
+            glue2_var_prefix + 'OperatingSystemRelease', list(CE_OS_RELEASE),
+            glue2_var_prefix + 'NetworkAdapterInboundIP', list(CE_INBOUNDIP),
+            glue2_var_prefix + 'NetworkAdapterOutboundIP', list(CE_OUTBOUNDIP),
+            glue2_var_prefix + 'Benchmarks', list(
+                format('(hep-spec06 %s)', to_string(hepspec06)),
+                format('(specfp2000 %s)', to_string(CE_SF00)),
+                format('(specint2000 %s)',to_string(CE)),
+            ),
+            glue2_var_prefix + 'Cores', list(to_string(average_core_num)),
+       );
     };
 
-    SELF["glue1"]["lcg-info-static-cesebind.conf"]['ldifFile'] = "static-file-CESEBind.ldif";
-    SELF["glue1"]["lcg-info-static-cesebind.conf"]['entries'] = close_se_entries_g1;
-  };
-
-
-  # Create LDIF configuration entries for GLUE2 (general parameters)
-  # FIXME: ServingState configuration
-  # FIXME: Argus paramater based on actual config
-  # FIXME: CE_BATCH_VERSION paramater based on actual config
-  # FIXME: CloseSEs: set LocalPath/RemotePath
-  # FIXME: manage ESComputingServiceID and WorkingAreaxxx attributes
-  ce_acbr = list();
-  foreach (i;vo;VOS) {
-    ce_acbr[length(ce_acbr)] = format('VO:%s',vo);
-  };
-  ce_shares = list();
-  foreach (lrms;share_entries;share_entries_g2) {
-    foreach (share;params;share_entries) {
-      ce_shares[length(ce_shares)] = to_uppercase(share);
-    }
-  };
-  ce_close_ses = list();
-  if ( is_defined(queue_close_se_list) ) {
-    foreach (i;se;queue_close_se_list) {
-      ce_close_ses[length(ce_close_ses)] = format('(%s none none)',se);
-    };
-  };
-  if ( CE_SHARED_HOMES ) {
-    working_area_shared = 'yes';
-  } else {
-    working_area_shared = 'no';
-  };
-  # FIXME: check what ImplementationVersion and InterfaceVersion should be (CE version or LRMS version)
-  SELF['glue2']['CEParameters'] = nlist('SiteId', list(SITE_NAME),
-                                        'ComputingServiceId', list(GIP_CLUSTER_PUBLISHER_HOST+'_ComputingElement'),
-                                        'NumberOfEndPointType', list('3'),
-                                        'ImplementationVersion', list(CREAM_CE_VERSION),
-                                        'InterfaceVersion', list(CREAM_CE_VERSION),
-                                        'HealthStateHelper', list(GIP_PROVIDER_SUBSERVICE['test']),
-                                        'ServingState', list('production'),
-                                        'Owner', VOS,
-                                        'Argus', list('no'),
-                                        'EMIES', list('no'),
-                                        'ACBR', ce_acbr,
-                                        'Shares', ce_shares,
-                                        'ExecutionEnvironments', list(GIP_CLUSTER_PUBLISHER_HOST),
-                                        'CE_BATCH_SYS', list(CE_BATCH_SYS),
-                                        'BATCH_VERSION', list('0.0.0.0'),
-                                        'CECapabilities', CE_CAPABILITIES,
-                                        'CloseSEs', ce_close_ses,
-                                        'WorkingAreaShared', list(working_area_shared),
-                                        #'WorkingAreaGuaranteed', list('no'),
-                                        #'WorkingAreaTotal', list('undefined'),
-                                        #'WorkingAreaFree', list('undefined'),
-                                        #'WorkingAreaLifeTime', list('undefined'),
-                                        #'WorkingAreaMultislotTotal', list('undefined'),
-                                        #'WorkingAreaMultislotFree', list('undefined'),
-                                        #'WorkingAreaMultislotLifeTime', list('undefined'),
-                                        #'ESComputingServiceId', list('undefined'),
-                                       );
-
-
-  # Create LDIF configuration entries for GLUE2 (execution environment parameters)
-  # FIXME: SmpSize, Cores. Define separate Execution Environments for different HW?
-  # FIXME: ProcessorVendor. Define separate Execution Environments for different HW?
-  # FIXME: ProcessorModel. Define separate Execution Environments for different HW?
-  # FIXME: ProcessorClockSpeed. Define separate Execution Environments for different HW?
-  if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) {
-    glue2_var_prefix = format('ExecutionEnvironment_%s_',GIP_CLUSTER_PUBLISHER_HOST);
-    SELF['glue2']['ExecutionEnvironment'] = nlist(glue2_var_prefix+'ArchitecturePlatformType', list(CE_WN_ARCH),
-                                                  glue2_var_prefix+'PhysicalCPUs', list(to_string(CE_CPU_CONFIG['cpus'])),
-                                                  glue2_var_prefix+'LogicalCPUs', list(to_string(CE_CPU_CONFIG['slots'])),
-                                                  glue2_var_prefix+'SmpSize', list(CE_SMPSIZE),
-                                                  glue2_var_prefix+'ProcessorVendor', list(CE_CPU_VENDOR),
-                                                  glue2_var_prefix+'ProcessorModel', list(CE_CPU_MODEL),
-                                                  glue2_var_prefix+'ProcessorClockSpeed', list(CE_CPU_SPEED),
-                                                  glue2_var_prefix+'MainMemoryRAMSize', list(CE_MINPHYSMEM),
-                                                  glue2_var_prefix+'MainMemoryVirtualSize', list(CE_MINVIRTMEM),
-                                                  glue2_var_prefix+'OperatingSystemFamily', list(CE_OS_FAMILY),
-                                                  glue2_var_prefix+'OperatingSystemName', list(CE_OS),
-                                                  glue2_var_prefix+'OperatingSystemRelease', list(CE_OS_RELEASE),
-                                                  glue2_var_prefix+'NetworkAdapterInboundIP', list(CE_INBOUNDIP),
-                                                  glue2_var_prefix+'NetworkAdapterOutboundIP', list(CE_OUTBOUNDIP),
-                                                  glue2_var_prefix+'Benchmarks', list(format('(HEPSPEC06 %s)',to_string(hepspec06)),
-                                                                                      format('(SF00 %s)',to_string(CE_SF00)),
-                                                                                      format('(SI00 %s)',to_string(CE_SI00)),
-                                                                                     ),
-                                                  glue2_var_prefix+'Cores', list(to_string(average_core_num)),
-                                                 );
-  };
-
-  SELF;
+    SELF;
 };
 
 
@@ -1113,43 +1157,47 @@ variable GIP_CE_LDIF_PARAMS = {
 # LDIF configuration is done differently for GLUE1 and GLUE2.
 #--------------------------------------------------------------------
 "/software/components/gip2" = {
-  if ( is_defined(SELF) && !is_nlist(SELF) ) {
-    error('/software/components/gip2/ldif must be an nlist');
-  };
-
-  if ( is_defined(GIP_CE_LDIF_PARAMS['glue1']) ) {
-    foreach (k;v;GIP_CE_LDIF_PARAMS['glue1']) {
-      SELF['ldif'][k] = v;
+    if ( is_defined(SELF) && !is_dict(SELF) ) {
+        error('/software/components/gip2/ldif must be an dict');
     };
-  };
 
-  if ( is_defined(GIP_CE_LDIF_PARAMS['glue2']) ) {
-    foreach (k;v;GIP_CE_LDIF_PARAMS['glue2']) {
-      if ( k == 'shares' ) {
-        foreach (k2;v2;GIP_CE_LDIF_PARAMS['glue2']['shares']) {
-          SELF['ldifConfEntries'][GIP_CE_GLUE2_CONFIG_FILE][k2] = v2;
+    if ( is_defined(GIP_CE_LDIF_PARAMS['glue1']) ) {
+        foreach (k; v; GIP_CE_LDIF_PARAMS['glue1']) {
+           SELF['ldif'][k] = v;
         };
-      } else if ( match('CEParameters|ExecutionEnvironment',k) ) {
-        SELF['ldifConfEntries'][GIP_CE_GLUE2_CONFIG_FILE][k] = GIP_CE_LDIF_PARAMS['glue2'][k]
-      };
     };
-    foreach (category;dummy;GIP_CE_GLUE2_LDIF_PROCESSORS) {
-      # When the host is not also the GIP_CLUSTER_PUBLISHER_HOST (in cluster mode),
-      # only the GLUE2ComputingService and the GLUE2ComputingEndpoint must be published.
-      if ( (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) || match('endpoint|service',category) ) {
-        SELF['ldif']['glue2_'+category]['staticInfoCmd'] = format('%s/%s',GIP_CE_GLUE2_LDIF_PROCESSOR_DIR,GIP_CE_GLUE2_LDIF_PROCESSORS[category]);
-        SELF['ldif']['glue2_'+category]['confFile'] = GIP_CE_GLUE2_CONFIG_FILE;
-        SELF['ldif']['glue2_'+category]['ldifFile'] = GIP_CE_GLUE2_LDIF_FILES[category];
-      };
-    };
-  };
 
-  SELF;
+    if ( is_defined(GIP_CE_LDIF_PARAMS['glue2']) ) {
+        foreach (k; v; GIP_CE_LDIF_PARAMS['glue2']) {
+            if ( k == 'shares' ) {
+                foreach (k2; v2; GIP_CE_LDIF_PARAMS['glue2']['shares']) {
+                    SELF['ldifConfEntries'][GIP_CE_GLUE2_CONFIG_FILE][k2] = v2;
+                };
+            } else if ( match('CEParameters|ExecutionEnvironment', k) ) {
+                SELF['ldifConfEntries'][GIP_CE_GLUE2_CONFIG_FILE][k] = GIP_CE_LDIF_PARAMS['glue2'][k]
+            };
+        };
+        foreach (category; dummy; GIP_CE_GLUE2_LDIF_PROCESSORS) {
+            # When the host is not also the GIP_CLUSTER_PUBLISHER_HOST (in cluster mode),
+            # only the GLUE2ComputingService and the GLUE2ComputingEndpoint must be published.
+            if ( (FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST) || match('endpoint|service',category) ) {    
+                SELF['ldif']['glue2_' + category]['staticInfoCmd'] = format(
+                    '%s/%s', 
+                    GIP_CE_GLUE2_LDIF_PROCESSOR_DIR,
+                    GIP_CE_GLUE2_LDIF_PROCESSORS[category]
+                );
+                SELF['ldif']['glue2_' + category]['confFile'] = GIP_CE_GLUE2_CONFIG_FILE;
+                SELF['ldif']['glue2_' + category]['ldifFile'] = GIP_CE_GLUE2_LDIF_FILES[category];
+            };
+        };
+    };
+
+    SELF;
 };
 
 
 #---------------------------------------------------------------
-# Configuration of the GlueService information provider for
+# Configuration of the GlueService information provider for 
 # CREAM CE and CEMON service.
 # Do not create if CE_FLAVOR is undefined (not a CE).
 #---------------------------------------------------------------
@@ -1178,34 +1226,34 @@ variable GIP_CE_LDIF_PARAMS = {
             if ( is_defined(GIP_CE_SERVICE_PARAMS[service]['version']) ) {
                 service_version_cmd = GIP_CE_SERVICE_PARAMS[service]['version'];
             } else if ( is_defined(GIP_CE_SERVICE_PARAMS[service]['version_rpm']) ) {
-                service_version_cmd = "rpm -q --qf %{V} "+GIP_CE_SERVICE_PARAMS[service]['version_rpm'];
+                service_version_cmd = "rpm -q --qf %{V} " + GIP_CE_SERVICE_PARAMS[service]['version_rpm'];
             } else {
-                error("Either 'version' or 'version_rpm' must be present in GIP_CE_SERVICE_PARAMS["+service+"]");
+                error("Either 'version' or 'version_rpm' must be present in GIP_CE_SERVICE_PARAMS[" + service + "]");
             };
-
-            SELF['confFiles'][escape(service_provider_conf)] =
-                "init = "+GIP_PROVIDER_SUBSERVICE[service]+" init\n" +
-                "service_type = "+GIP_CE_SERVICE_PARAMS[service]['type']+"\n" +
-                "get_version = "+service_version_cmd+"\n" +
-                "get_endpoint = echo " + GIP_CE_SERVICE_PARAMS[service]['endpoint']+"\n" +
+      
+            SELF['confFiles'][escape(service_provider_conf)] = 
+                "init = " + GIP_PROVIDER_SUBSERVICE[service] + " init\n" +
+                "service_type = " + GIP_CE_SERVICE_PARAMS[service]['type'] + "\n" +
+                "get_version = " + service_version_cmd + "\n" +
+                "get_endpoint = echo " + GIP_CE_SERVICE_PARAMS[service]['endpoint'] +"\n" +
                 "get_status = " + GIP_PROVIDER_SUBSERVICE['test'] + " " + GIP_CE_SERVICE_PARAMS[service]['service_status_name'] +
                     " && /sbin/service " + GIP_CE_SERVICE_PARAMS[service]['service'] + " status\n" +
                 "WSDL_URL = " + GIP_CE_SERVICE_PARAMS[service]['wsdl'] + "\n" +
                 "semantics_URL = " + GIP_CE_SERVICE_PARAMS[service]['semantics'] + "\n" +
-                "get_starttime =  perl -e '@st=stat("+GIP_CE_SERVICE_PARAMS[service]['pid_file']+");print \"@st[10]\\n\";'\n" +
-                "get_owner ="+service_owner_cmd+"\n" +
-                "get_acbr ="+service_acbr_cmd+"\n" +
+                "get_starttime =  perl -e '@st=stat(" + GIP_CE_SERVICE_PARAMS[service]['pid_file'] + ");print \"@st[10]\\n\";'\n" +
+                "get_owner =" + service_owner_cmd + "\n" +
+                "get_acbr =" + service_acbr_cmd + "\n" +
                 "get_data =  echo -en " + GIP_CE_SERVICE_PARAMS[service]['service_data'] + "\n" +
                 "get_implementationname = echo " + GIP_CE_SERVICE_PARAMS[service]['implementationname'] + "\n" +
-                "get_implementationversion = "+service_version_cmd+"\n" +
+                "get_implementationversion = " + service_version_cmd + "\n" +
                 "get_services = echo\n";
             SELF['provider'][service_provider_wrapper] =
-                "#!/bin/sh\n" +
+                "#!/bin/sh\n" + 
                 GIP_PROVIDER_SERVICE + ' ' + service_provider_conf + ' ' + SITE_NAME + ' ' + service_uniqueid + "\n";
 
             # Glue v2
             SELF['provider'][service_provider_wrapper + '-glue2'] =
-                "#!/bin/sh\n" +
+                "#!/bin/sh\n" + 
                 GIP_PROVIDER_SERVICE + '-glue2 ' + service_provider_conf + ' ' + SITE_NAME + ' ' + service_uniqueid + "\n";
         };
     };
@@ -1220,19 +1268,19 @@ include if ( GIP_CE_USE_MAUI && (FULL_HOSTNAME == LRMS_SERVER_HOST) ) 'features/
 # Define permissions/owner for some key directories
 include { 'components/dirperm/config' };
 '/software/components/dirperm/paths' = {
-    append(nlist(
+    append(dict(
         'owner','ldap:ldap',
         'path', '/var/lib/bdii/db/grid',
         'perm', '0755',
         'type', 'd',
     ));
-    append(nlist(
+    append(dict(
         'owner','ldap:ldap',
         'path', '/var/lib/bdii/db/glue',
         'perm','0755',
         'type','d',
     ));
-    append(nlist(
+    append(dict(
         'owner','ldap:ldap',
         'path','/var/lib/bdii/db/stats',
         'perm','0755',

--- a/features/gip/ce.pan
+++ b/features/gip/ce.pan
@@ -616,13 +616,9 @@ variable GIP_CE_LDIF_PARAMS = {
                 jobmanager=CE_JM_TYPE;
                 lrms = jobmanager;
             };
-            foreach (i; ce; CE_HOSTS) {
-                if ( index(ce,CE_HOSTS_CREAM) >= 0 ) {
-                    ce_flavor = 'cream';
-                } else {
-                    error(format('Non CREAM CE found (%s): only CREAM CE are supported', ce));
-                };
-        
+            foreach (i; ce; CE_HOSTS_CREAM) {
+
+                ce_flavor = 'cream'; 
                 if ( ce_flavor == 'cream' ) {
                     # CREAM CE doesn't know about all LCG CE job manager variants...
                     jobmanager = lrms;
@@ -730,7 +726,7 @@ variable GIP_CE_LDIF_PARAMS = {
             # FIXME: cache mode should not be specific to Torque/MAUI...
             # FIXME: cluster mode (distinct CEs and LRMS master) validation with LRMS other than Torque/MAUI 
             if ( FULL_HOSTNAME == GIP_CLUSTER_PUBLISHER_HOST ) { ##Changed LRMS_SERVER_HOST->GIP_CLUSTER_PUBLISHER_HOST
-                ce_list = CE_HOSTS;
+                ce_list = merge(CE_HOSTS_LCG, CE_HOSTS_CREAM);
                 # Create only if necessary to avoid creating a useless emtpy file
                 # FIXME: when lcg-info-dynamic-scheduler is fixed to allow publishing GlueCE/GlueVOView on the CE,
                 #        initialize all_ce_entries_g1[lrms] only if GIP_CE_USE_CACHE is true.
@@ -1142,7 +1138,7 @@ variable GIP_CE_LDIF_PARAMS = {
             glue2_var_prefix + 'Benchmarks', list(
                 format('(hep-spec06 %s)', to_string(hepspec06)),
                 format('(specfp2000 %s)', to_string(CE_SF00)),
-                format('(specint2000 %s)',to_string(CE)),
+                format('(specint2000 %s)',to_string(CE_SI00)),
             ),
             glue2_var_prefix + 'Cores', list(to_string(average_core_num)),
        );

--- a/features/gip/files/info-dynamic-condor
+++ b/features/gip/files/info-dynamic-condor
@@ -19,8 +19,9 @@ class InfoDynamicCondor(object):
         self.version = htcondor.version()[16:22]
         self.cpus = 0
         self.free = 0
+        self.processors = 0
         self.vo = {}
-        # TODO: This value should be compute
+        # TODO: This value should be computed
         self.max_waiting = 2000
         self.max_memory = 2048
         self.max_slot_per_job = 8
@@ -39,12 +40,21 @@ class InfoDynamicCondor(object):
         worker_nodes = collector.query(htcondor.AdTypes.Startd)
         self.total_cpus(worker_nodes)
         self.total_free(worker_nodes)
+        self.total_machines(worker_nodes)
 
         # Scheduler provide information about jobs
         scheduler_address = collector.locate(htcondor.DaemonTypes.Schedd, self.scheduler_address)
         scheduler = htcondor.Schedd(scheduler_address)
         jobs = scheduler.query()
         self.per_vo_jobs(jobs)
+
+    def total_machines(self, worker_nodes):
+        """
+        just count the number of processors (assuming machines are all bi proc)
+        """
+        for worker_node in worker_nodes:
+            if not ('DynamicSlot' in worker_node):
+                self.processors += 2
 
     def total_cpus(self, worker_nodes):
         """
@@ -87,17 +97,20 @@ class InfoDynamicCondor(object):
             # We only considere Running and Idle job, we ignore any other state (completed, ...)
             if job['JobStatus'] == 1 or job['JobStatus'] == 2:
                 # If this is the first job for this VO we create a empty entry
-                if job['x509UserProxyVOName'] not in self.vo:
-                    self.vo[job['x509UserProxyVOName']] = {'total': 0,
-                                                           'running': 0,
-                                                           'waiting': 0
-                                                           }
-                # TODO: Is it really useful ?
-                self.vo[job['x509UserProxyVOName']]['total'] += 1
-                if job['JobStatus'] == 1:
-                    self.vo[job['x509UserProxyVOName']]['waiting'] += 1
-                else:
-                    self.vo[job['x509UserProxyVOName']]['running'] += 1
+                try:
+                    if job['x509UserProxyVOName'] not in self.vo:
+                        self.vo[job['x509UserProxyVOName']] = {'total': 0,
+                                                               'running': 0,
+                                                               'waiting': 0
+                                                               }
+                    # TODO: Is it really useful ?
+                    self.vo[job['x509UserProxyVOName']]['total'] += 1
+                    if job['JobStatus'] == 1:
+                        self.vo[job['x509UserProxyVOName']]['waiting'] += 1
+                    else:
+                        self.vo[job['x509UserProxyVOName']]['running'] += 1
+                except KeyError:
+                    pass
 
 
 class ConsoleView(object):
@@ -121,6 +134,7 @@ class Glue1View(object):
     def display(dynamic_information, glue1_ldif):
         options = dynamic_information.__dict__
         options['waiting'] = dynamic_information.total_waiting()
+        options['serving_status'] = options['status'].lower()
         file = open(glue1_ldif, "r")
         for line in file:
             if line.startswith('dn: GlueCEUniqueID='):
@@ -133,7 +147,7 @@ class Glue1View(object):
                       "GlueCEPolicyMaxRunningJobs: {cpus}\n" \
                       "GlueCEPolicyMaxWallClockTime: {max_wall_clock_time}\n" \
                       "GlueCEPolicyMaxCPUTime: {max_cpu_time}\n" \
-                      "GlueCEStateStatus: {status}\n" \
+                      "GLUE2ComputingShareServingState: {serving_status}\n" \
                       "GlueCEInfoLRMSVersion: {version}\n" \
                       "GlueCEInfoLRMSType: {name}".format(**options)
         file.close()
@@ -144,12 +158,15 @@ class Glue2View(object):
     Class to display into GLUE2 information
     """
     @staticmethod
-    def display(dynamic_information, glue2_ldif):
+    def display(dynamic_information, glue2_ldif, ee_ldif):
         # TODO: Make a per-vo output instead of global output
         options = dynamic_information.__dict__
         options['waiting'] = dynamic_information.total_waiting()
         options['max_total'] = dynamic_information.max_waiting + dynamic_information.cpus
-        options['current_date'] = datetime.datetime.now().isoformat()
+        options['current_date'] = datetime.datetime.now().isoformat().split('.')[0]
+        options['serving_status'] = options['status'].lower()
+        options['pcpus']=str(round(options['cpus']/2,0)).split('.')[0]
+        options['cores']=str(round(options['cpus']/options['processors'],0)).split('.')[0]
         file = open(glue2_ldif, "r")
         for line in file:
             if line.startswith('dn: GLUE2ShareID'):
@@ -159,7 +176,6 @@ class Glue2View(object):
                              "GLUE2ComputingShareMaxWaitingJobs: {max_waiting}\n" \
                              "GLUE2ComputingShareMaxTotalJobs: {max_total}\n" \
                              "GLUE2ComputingShareServingState: {status}\n" \
-                             "GLUE2ComputingShareWaitingJobs: {waiting}\n" \
                              "GLUE2EntityCreationTime: {current_date}\n" \
                              "GLUE2ComputingShareMaxWallTime: {max_wall_clock_time}\n" \
                              "GLUE2ComputingShareDefaultWallTime: {max_wall_clock_time}\n" \
@@ -170,7 +186,19 @@ class Glue2View(object):
                              "GLUE2ComputingShareMaxVirtualMemory: {max_virtual_memory}" \
                              "".format(**options)
         file.close()
-
+        file = open(ee_ldif, "r")
+        for line in file:
+            if line.startswith('dn: GLUE2ResourceID'):
+                print line + "" \
+                             "GLUE2ExecutionEnvironmentLogicalCPUs: {cpus}\n" \
+                             "GLUE2ExecutionEnvironmentPhysicalCPUs: {processors}\n" \
+                             "GLUE2ExecutionEnvironmentTotalInstances: {pcpus}\n" \
+                             "GLUE2ExecutionEnvironmentCPUClockSpeed: 2400\n" \
+                             "GLUE2ExecutionEnvironmentMainMemorySize: {max_memory}\n" \
+                             "GLUE2ExecutionEnvironmentVirtualMemorySize: {max_virtual_memory}\n" \
+                             "GLUE2EntityOtherInfo: Cores={cores}" \
+                             "".format(**options)
+        file.close()
 
 def main():
     """
@@ -184,6 +212,7 @@ def main():
     parser.add_argument('--scheduler', dest='scheduler', help='Address of scheduler')
     parser.add_argument('--glue1-ldif', dest='glue1_ldif', help='Path to GLUE1 ldif file')
     parser.add_argument('--glue2-ldif', dest='glue2_ldif', help='Path to GLUE2 ldif file')
+    parser.add_argument('--ee-ldif', dest='ee_ldif', help='Path to GLUE2 ExecEnv ldif file')
     options = parser.parse_args()
 
     ##############################################
@@ -199,8 +228,8 @@ def main():
     # ConsoleView.display(dynamic_information)
     if options.glue1_ldif is not None:
         Glue1View.display(dynamic_information, options.glue1_ldif)
-    if options.glue2_ldif is not None:
-        Glue2View.display(dynamic_information, options.glue2_ldif)
+    if (options.glue2_ldif is not None) and (options.ee_ldif is not None):
+        Glue2View.display(dynamic_information, options.glue2_ldif, options.ee_ldif)
 
 if __name__ == '__main__':
     main()

--- a/features/gip/files/lcg-info-dynamic-condor
+++ b/features/gip/files/lcg-info-dynamic-condor
@@ -1,112 +1,210 @@
-#!/usr/bin/env perl
+#!/usr/bin/env python
+# coding: utf8
 
-use strict;
-use warnings;
-use FileHandle;
-use POSIX qw(strftime);
-
-# Parse the command line
-my ($PATH, $LDIF_FILE, $MANAGER) = @ARGV;
-unless ($PATH && $LDIF_FILE)
-{
-    print "Usage: $0 <condor path> <ldif file> [central manager]\n";
-
-    exit 1;
-}
-
-my $fh = new FileHandle $LDIF_FILE
-    or die "Can't open static ldif file: $LDIF_FILE\n";
-my @dns = grep /dn:\s+GlueCEUniqueID=/, <$fh>;
-
-# All the dynamic info goes in here
-my %glue;
-$glue{GlueCEInfoLRMSType} = "condor";
-
-# Figure out the correct central manager
-chomp(my $central_manager = $MANAGER ? $MANAGER : `$PATH/condor_config_val CONDOR_HOST`);
-
-# Condor version
-# Note: this is only the version of this node -- there's probably a
-# whole bunch of different versions running on the pool
-my ($version) = map { /(\d+\.\d+\.\d+)/; $1 }
-    grep /CondorVersion:/, `$PATH/condor_version`;
-$glue{GlueCEInfoLRMSVersion} = $version;
-
-# CPU stats
-# For our purposes CPU := VM
-# It's fine if you have 100 cpus free, but who cares if that can only
-# run one job at a time.  The official definition is:
-#    Number of free CPUs available to a scheduler
-# So I don't think that's entirely wrong.
-my $startd_status = `$PATH/condor_status -pool $central_manager`;
-my ($total_vms, $owner_vms, $idle_vms) =
-    $startd_status =~ /Total\s+(\d+)\s+(\d+)\s+\d+\s+(\d+)/;
-$glue{GlueCEInfoTotalCPUs} = $total_vms;
-$glue{GlueCEPolicyAssignedJobSlots} = $total_vms;
-$glue{GlueCEStateFreeCPUs} = $idle_vms;
-$glue{GlueCEStateFreeJobSlots} = $idle_vms;
-$glue{GlueCEPolicyMaxRunningJobs} = $total_vms;
-$glue{GlueCEPolicyMaxWallClockTime} = '2160'; #To be fixed!! shoud recover the max wct from some policy file
-$glue{GlueCEPolicyMaxCPUTime} = '2160'; #To be fixed!! shoud recover the max cput from some policy file
-$glue{GlueCEStateStatus} = 'Production'; #To be fixed!! shoud recover this frmo conf
-
-# Job stats
-# Held jobs are included as "waiting" since the definition is:
-#    Number of jobs that are in a state different than running
-#my $schedd_status = `$PATH/condor_status -pool $central_manager -schedd`;
-#my ($running_jobs, $idle_jobs, $held_jobs) =
-#    $schedd_status =~ /Total\s+(\d+)\s+(\d+)\s+(\d+)/;
-#$glue{GlueCEStateWaitingJobs} = $idle_jobs + $held_jobs;
-#$glue{GlueCEStateRunningJobs} = $running_jobs;
-#$glue{GlueCEStateTotalJobs} = $idle_jobs + $running_jobs + $held_jobs;
+import htcondor
+import argparse
+import datetime
 
 
-#GlueCEPolicyMaxRunningJobs: 1590
-#GlueCEPolicyMaxWallClockTime: 2160
-#GlueCEPolicyMaxCPUTime: 1440
-#GlueCEStateStatus: Production
+class InfoDynamicCondor(object):
+    """
+    InfoDynamicCondor is a object to store usefull data
+    """
+    def __init__(self, scheduler_address):
+        """
+        Initialize InfoDynamicCondor
+        """
+        self.name = "condor"
+        self.scheduler_address = scheduler_address
+        self.version = htcondor.version()[16:22]
+        self.cpus = 0
+        self.free = 0
+        self.vo = {}
+        # TODO: This value should be compute
+        self.max_waiting = 2000
+        self.max_memory = 2048
+        self.max_slot_per_job = 8
+        self.max_virtual_memory = 3072
+        self.max_wall_clock_time = 2160
+        self.max_cpu_time = 2160
+        self.status = 'Production'
+
+    def load(self):
+        """
+        Retrieve information from HTCondor and populate object with it
+        """
+        collector = htcondor.Collector()
+
+        # Collector provide information about worker node state
+        worker_nodes = collector.query(htcondor.AdTypes.Startd)
+        self.total_cpus(worker_nodes)
+        self.total_free(worker_nodes)
+
+        # Scheduler provide information about jobs
+        scheduler_address = collector.locate(htcondor.DaemonTypes.Schedd, self.scheduler_address)
+        scheduler = htcondor.Schedd(scheduler_address)
+        jobs = scheduler.query()
+        self.per_vo_jobs(jobs)
+
+    def total_cpus(self, worker_nodes):
+        """
+        cpus is just a addition of Cpus find on all Worker Node
+        """
+        for worker_node in worker_nodes:
+            self.cpus += worker_node['Cpus']
+
+    def total_free(self, worker_nodes):
+        """
+        Each Cpus in worker node unclaimed is considered free
+        """
+        for worker_node in worker_nodes:
+            if worker_node['State'] == "Unclaimed":
+                self.free += worker_node['Cpus']
+
+    def total_running(self):
+        """
+        Running job is a addition of all job running for each vo
+        """
+        running = 0
+        for vo in self.vo:
+            running += self.vo[vo]['running']
+        return running
+
+    def total_waiting(self):
+        """
+        Waiting job is a addition of all job waiting for each vo
+        """
+        waiting = 0
+        for vo in self.vo:
+            waiting += self.vo[vo]['waiting']
+        return waiting
+
+    def per_vo_jobs(self, jobs):
+        """
+        Compute information about job for each VO
+        """
+        for job in jobs:
+            # We only considere Running and Idle job, we ignore any other state (completed, ...)
+            if job['JobStatus'] == 1 or job['JobStatus'] == 2:
+                # If this is the first job for this VO we create a empty entry
+                try:
+                    if job['x509UserProxyVOName'] not in self.vo:
+                        self.vo[job['x509UserProxyVOName']] = {'total': 0,
+                                                               'running': 0,
+                                                               'waiting': 0
+                                                               }
+                    # TODO: Is it really useful ?
+                    self.vo[job['x509UserProxyVOName']]['total'] += 1
+                    if job['JobStatus'] == 1:
+                        self.vo[job['x509UserProxyVOName']]['waiting'] += 1
+                    else:
+                        self.vo[job['x509UserProxyVOName']]['running'] += 1
+                except KeyError:
+                    pass
 
 
-# Time stuff
-# WorstResponseTime is impossible to determine and a reasonable estimate
-#   would required lots of time (15 minutes+) on active pools.
-# EstimatedResponseTime is equally impossible.  Anything here would just
-#   be garbage so it's best if people put it in their static file.
-
-# Output the info
-foreach my $dn (@dns)
-{
-    print "$dn\n";
-    print map { "$_: $glue{$_}\n" } keys %glue;
-}
-
-#Managing the Glue2 stuff
-
-my $fh = new FileHandle '/var/lib/bdii/gip/ldif/ComputingShare.ldif'
-    or die "Can't open static Shares file: /var/lib/bdii/gip/ldif/ComputingShare.ldif\n";
-my @dns2 = grep /dn: GLUE2ShareID=/, <$fh>;
-
-my %glue2;
+class ConsoleView(object):
+    """
+    Class to display a human reading format of status
+    """
+    @staticmethod
+    def display(dynamic_information):
+        print("Cpus: %s" % dynamic_information.cpus)
+        print("Free: %s" % dynamic_information.free)
+        print("Waiting: %s" % dynamic_information.total_waiting())
+        print("Running: %s" % dynamic_information.total_running())
+        print("Per-VO: %s" % dynamic_information.vo)
 
 
-$glue2{GLUE2ComputingShareFreeSlots}= $idle_vms;
-$glue2{GLUE2ComputingShareMaxRunningJobs}= $total_vms;
-$glue2{GLUE2ComputingShareMaxWaitingJobs}= $total_vms*2;
-$glue2{GLUE2ComputingShareMaxTotalJobs}= $total_vms*3;
-$glue2{GLUE2ComputingShareServingState}= 'Production';
-$glue2{GLUE2EntityCreationTime}= strftime '%FT%TZ', gmtime();
-$glue2{GLUE2ComputingShareMaxWallTime}= 2160;   #TO be fixed. All this should be taken from some conf.
-$glue2{GLUE2ComputingShareDefaultWallTime}= 2160;
-$glue2{GLUE2ComputingShareMaxCPUTime}= 1440;
-$glue2{GLUE2ComputingShareDefaultCPUTime}= 1440;
-$glue2{GLUE2ComputingShareMaxSlotsPerJob}= 1;
-$glue2{GLUE2ComputingShareMaxMainMemory}= 2000;
-$glue2{GLUE2ComputingShareMaxVirtualMemory}= 20000;
+class Glue1View(object):
+    """
+    Class to display into GLUE1 information
+    """
+    @staticmethod
+    def display(dynamic_information, glue1_ldif):
+        options = dynamic_information.__dict__
+        options['waiting'] = dynamic_information.total_waiting()
+        options['serving_status'] = options['status'].lower()
+        file = open(glue1_ldif, "r")
+        for line in file:
+            if line.startswith('dn: GlueCEUniqueID='):
+                print line + "" \
+                      "GlueCEInfoTotalCPUs: {cpus}\n" \
+                      "GlueCEPolicyAssignedJobSlots: {cpus}\n" \
+                      "GlueCEStateWaitingJobs: {waiting}\n" \
+                      "GlueCEStateFreeCPUs: {free}\n" \
+                      "GlueCEStateFreeJobSlots: {free}\n" \
+                      "GlueCEPolicyMaxRunningJobs: {cpus}\n" \
+                      "GlueCEPolicyMaxWallClockTime: {max_wall_clock_time}\n" \
+                      "GlueCEPolicyMaxCPUTime: {max_cpu_time}\n" \
+                      "GLUE2ComputingShareServingState: {serving_status}\n" \
+                      "GlueCEInfoLRMSVersion: {version}\n" \
+                      "GlueCEInfoLRMSType: {name}".format(**options)
+        file.close()
 
-foreach my $dn (@dns2)
-{
-    print "\n$dn\n";
-    print map { "$_: $glue2{$_}\n" } keys %glue2;
-}
+
+class Glue2View(object):
+    """
+    Class to display into GLUE2 information
+    """
+    @staticmethod
+    def display(dynamic_information, glue2_ldif):
+        # TODO: Make a per-vo output instead of global output
+        options = dynamic_information.__dict__
+        options['waiting'] = dynamic_information.total_waiting()
+        options['max_total'] = dynamic_information.max_waiting + dynamic_information.cpus
+        options['current_date'] = datetime.datetime.now().isoformat().split('.')[0]
+        options['serving_status'] = options['status'].lower()
+        file = open(glue2_ldif, "r")
+        for line in file:
+            if line.startswith('dn: GLUE2ShareID'):
+                print line + "" \
+                             "GLUE2ComputingShareFreeSlots: {free}\n" \
+                             "GLUE2ComputingShareMaxRunningJobs: {cpus}\n" \
+                             "GLUE2ComputingShareMaxWaitingJobs: {max_waiting}\n" \
+                             "GLUE2ComputingShareMaxTotalJobs: {max_total}\n" \
+                             "GLUE2ComputingShareServingState: {status}\n" \
+                             "GLUE2EntityCreationTime: {current_date}\n" \
+                             "GLUE2ComputingShareMaxWallTime: {max_wall_clock_time}\n" \
+                             "GLUE2ComputingShareDefaultWallTime: {max_wall_clock_time}\n" \
+                             "GLUE2ComputingShareMaxCPUTime: {max_cpu_time}\n" \
+                             "GLUE2ComputingShareDefaultCPUTime: {max_cpu_time}\n" \
+                             "GLUE2ComputingShareMaxSlotsPerJob: {max_slot_per_job}\n" \
+                             "GLUE2ComputingShareMaxMainMemory: {max_memory}\n" \
+                             "GLUE2ComputingShareMaxVirtualMemory: {max_virtual_memory}" \
+                             "".format(**options)
+        file.close()
 
 
+def main():
+    """
+    Main function for info-dynamic-condor
+    """
+    ###################
+    # Argument parser #
+    ###################
+    parser = argparse.ArgumentParser(description="info-dynamic-condor return a GLUE1 / GLUE2 output"
+                                                 "of condor scheduler state")
+    parser.add_argument('--scheduler', dest='scheduler', help='Address of scheduler')
+    parser.add_argument('--glue1-ldif', dest='glue1_ldif', help='Path to GLUE1 ldif file')
+    parser.add_argument('--glue2-ldif', dest='glue2_ldif', help='Path to GLUE2 ldif file')
+    options = parser.parse_args()
+
+    ##############################################
+    # Retrieve dynamic information from HTCondor #
+    ##############################################
+    dynamic_information = InfoDynamicCondor(options.scheduler)
+    dynamic_information.load()
+
+    #######################
+    # Display information #
+    #######################
+    # print "ConsoleView"
+    # ConsoleView.display(dynamic_information)
+    if options.glue1_ldif is not None:
+        Glue1View.display(dynamic_information, options.glue1_ldif)
+    if options.glue2_ldif is not None:
+        Glue2View.display(dynamic_information, options.glue2_ldif)
+
+if __name__ == '__main__':
+    main()

--- a/features/gip/files/lrmsinfo-condor
+++ b/features/gip/files/lrmsinfo-condor
@@ -1,116 +1,98 @@
-#! /usr/bin/perl
+#!/usr/bin/env python
+# coding: utf8
 
-use strict;
-use warnings;
-use Data::Dumper;
-use Switch;
+import time
+import htcondor
+import argparse
+import datetime
 
-open(CONDOR_STATUS,"/usr/bin/condor_status -startd -long|") or die "cannot execute condor_status";
 
-my $totals={
-    'nactive' => 0,
-    'nfree'   => 0,
-    'now'     => time(),
-    'schedCycle' => 26
-};
+collector = htcondor.Collector()
 
-my $res_info={};
+workers=collector.query(htcondor.AdTypes.Startd)
 
-while(<CONDOR_STATUS>){
-    if(/^$/){
-        addResInfo($res_info,$totals);
-        $res_info={};
-        next;
-    }elsif(/^(\S+) = (.+)$/){
-        $res_info->{$1}=$2
-    }else{
-        die "unrecognized classadd def";
-    }
-}
+class StartdInfo(object):
+    """
+    Startd is a object to store usefull data
+    """
+    def __init__(self,collector):
+        """
+        Initialize StartdInfo
+        """
+        self.totals={
+            'nactive' : 0,
+            'nfree'   : 0,
+            'now'     : "%d" % time.time(),
+            'schedCycle' : 26
+        }
+        for wn in collector.query(htcondor.AdTypes.Startd):
+            self.totals['nactive']+=wn['Cpus']
+            if wn['State'] == '"Claimed"':
+               self.totals['nfree']+=wn['Cpus']
 
-$res_info={};
+    def printAll(self):
+        print """
+nactive\t{nactive}
+nfree\t{nfree}
+now\t{now}
+schedCycle\t{schedCycle}
+""".format(**self.totals)
 
-close CONDOR_STATUS;
 
-printTotals($totals);
+class ScheddInfo(object):
+    """
+    Startd is a object to store usefull data
+    """
+    def __init__(self,collector):
+        """
+        Initialize ScheddInfo
+        """
+        self.scheduler=htcondor.Schedd(collector.locateAll(htcondor.DaemonTypes.Schedd)[0])
 
-open(CONDOR_Q,"/usr/bin/condor_q -global -long|") or die "cannot execute condor_q";
+    def printAll(self):
+        for jobca in self.scheduler.query():
 
-my $job_info={};
+            # This is a kludge: jobca is a classad object and it
+            # seems to give some problem when adding fields. 
+            # copying it into simple dictionary does teh job.
+            job = {}
 
-while(<CONDOR_Q>){
-   if(/^$/){
-       printJobInfo($job_info);
-       $job_info={};
-       next;
-   }elsif(/^(\S+) = (.+)$/){
-       $job_info->{$1}=$2
-   }else{
-       $job_info={};
-   }
-}
+            for x in jobca.keys():
+                job[x] = jobca[x]
 
-close CONDOR_Q;
+            (job['user'], job['queue']) = job['User'].split('@')
+            try:
+                job['group'] = job['x509UserProxyVOName'].split('"')[0]
+            except:
+                job['group'] = "no-group"
 
-sub addResInfo {
-    my $info=shift;
-    my $tot=shift;
+            if job['JobStatus'] == 0 or job['JobStatus'] == 1:
+                job['status'] = 'queued'
+            elif job['JobStatus'] == 2:
+                job['status'] = 'running'
+            else:
+                continue
 
-#    print "DBP1:",Dumper($info),"\n";
-#    print "DBP1:",Dumper($tot),"\n";
+            if 'JobStartDate' in job.keys():
+                job['walltime'] = ("%d" % (time.time()-job['JobStartDate']))
+            else:
+                job['walltime'] = 0.0
+                job['JobStartDate'] = job['QDate']
 
-    $tot->{nactive} = $tot->{nactive} + $info->{Cpus};
-    $tot->{nfree} = $tot->{nfree} + $info->{Cpus} unless($info->{State} eq '"Claimed"');
+            if job['status'] == 'queued' and (time.time() - job['QDate']) < 3600:
+                continue
 
-}
+            try:
+                job['CreamQueue'] = job['CreamQueue'].split('"')[0]
+            except:
+                job['CreamQueue'] = 'no-cream-queue'
 
-sub printTotals{
-    my $tot=shift;
-    foreach my $key (keys(%{$tot})){
-        print "$key\t$tot->{$key}\n"
-    }
+            jobstr = "'group': '{group}', 'name': 'condor_{ClusterId}', 'qtime': {QDate}, 'jobid': {ClusterId}, 'queue': '{CreamQueue}', 'start': {JobStartDate}," \
+                  " 'state': '{status}', 'cpucount': {RequestCpus}, 'user': '{User}', 'maxwalltime': 129600, 'startAnchor': 'start_time', 'walltime': {walltime}"\
+                  "".format(**job)
+            print "{%s}" % jobstr
 
-}
+StartdInfo(htcondor.Collector()).printAll()
 
-sub printJobInfo {
-    my $info=shift;
+ScheddInfo(htcondor.Collector()).printAll()
 
-    $info->{User}=~/"(\S+)@(\S+)"/;
-    $info->{user}=$1;
-    $info->{queue}=$2;
-
-    $info->{x509UserProxyVOName}=~/"(\S+)"/;
-    $info->{group}=$1;
-
-    switch($info->{JobStatus}){
-        case [0,1]{$info->{status}='queued'}
-        case 2 {$info->{status}='running'}
-        else {return};
-    };
-
-    if(defined($info->{JobStartDate})){
-        $info->{walltime}=time()-$info->{JobStartDate};
-    }else{
-        $info->{JobStartDate} = $info->{QDate};
-        $info->{walltime}=0.0;
-    }
-
-    $info->{CreamQueue}=~/([^"]+)/;
-    $info->{CreamQueue}=$1;
-
-    print "{'group': '".$info->{group}."', ";
-    print "'name': 'condor_".$info->{ClusterId}."', ";
-    print "'qtime': ".$info->{QDate}.", ";
-    print "'jobid': '".$info->{ClusterId}."', ";
-    print "'queue': '".$info->{CreamQueue}."', ";
-    #print "'queue': 'default',";
-    print "'start': ".$info->{JobStartDate}.", ";
-    print "'state': '".$info->{status}."', ";
-    print "'cpucount': ".$info->{RequestCpus}.", ";
-    print "'user': '".$info->{user}."', ";
-    print "'maxwalltime': 129600,"; #to be fixed
-    print "'startAnchor': 'start_time',";
-    print "'walltime': ".$info->{walltime}." ";
-
-    print "}\n";
-}

--- a/features/htcondor/client/ce.pan
+++ b/features/htcondor/client/ce.pan
@@ -1,7 +1,5 @@
 unique template features/htcondor/client/ce;
 
-variable CONDOR_FIX_QUEUE_SUPER_USERS ?= false;
-
 variable CONDOR_CONFIG = {
     if (FULL_HOSTNAME == LRMS_SERVER_HOST) {
         file_list = list('submit');
@@ -18,18 +16,13 @@ variable CONDOR_CONFIG = {
         SELF['options']['submit'] = dict();
     };
 
-    if(!is_defined(SELF['queue_superusers_list'])){
-        SELF['queue_superusers_list'] = 'tomcat';
-    };
-
     SELF;
 };
 
 
 include 'features/htcondor/server/groups';
 include 'features/htcondor/client/policies';
-
-variable BLPARSER_WITH_UPDATER_NOTIFIER = true;
+include 'features/htcondor/client/job-transform';
 
 variable CE_QUEUES ?= dict(
     'vos', dict(
@@ -37,30 +30,5 @@ variable CE_QUEUES ?= dict(
     ),
 );
 
-# Fixme: a bug in the blah RPM
-variable HTCONDOR_FIX_BLAH ?= true;
-include if(HTCONDOR_FIX_BLAH) 'features/htcondor/client/fix-blah';
-
-include 'components/dirperm/config';
-
-'/software/components/dirperm/paths' = push(
-    dict(
-        'path', '/var/glite/',
-        'type', 'd',
-        'owner', 'glite:tomcat',
-        'perm', '775'
-    )
-);
-
-'/software/components/dirperm/paths' = push(
-    dict(
-        'path', '/var/glite/blah',
-        'type', 'd',
-        'owner', 'tomcat',
-        'perm', '775'
-    )
-);
-
-include 'components/chkconfig/config';
-
-'/software/components/chkconfig/service/glite-ce-blah-parser' = dict('on', '', 'startstop', true);
+include if(CE_FLAVOR == 'condorce') 'features/htcondor/client/condorce/config';
+include if(CE_FLAVOR == 'cream') 'features/htcondor/client/creamce';

--- a/features/htcondor/client/condorce/apel.pan
+++ b/features/htcondor/client/condorce/apel.pan
@@ -16,7 +16,7 @@ variable CONDOR_CONFIG = {
         if(SELF['apel_partial']){
             SELF['apel_script'] = '/usr/share/condor-ce/condor_ce_apel_partial.sh';
         }else{
-            SELF['apel_script']	= '/usr/share/condor-ce/condor_ce_apel.sh';
+            SELF['apel_script'] = '/usr/share/condor-ce/condor_ce_apel.sh';
         };
     };
 
@@ -38,14 +38,14 @@ include 'features/accounting/apel/parser_htcondorce';
 
 variable CONDOR_CONFIG = {
 
-   # Adding the condor bdii config
-   SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
-            'name', 'apel',
-            'contents', 'features/htcondor/templ/apel',
-            'base_path', SELF['ce_cfgdir'],
-        ));
+    # Adding the condor bdii config
+    SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
+        'name', 'apel',
+        'contents', 'features/htcondor/templ/apel',
+        'base_path', SELF['ce_cfgdir'],
+    ));
 
-   SELF;
+    SELF;
 };
 
 #
@@ -54,7 +54,7 @@ variable CONDOR_CONFIG = {
 
 include 'components/filecopy/config';
 
-prefix '/software/components/filecopy/services/';
+prefix '/software/components/filecopy/services';
 
 '{/usr/share/condor-ce/condor_ce_apel_partial.sh}' = dict(
     'config', file_contents('features/htcondor/templ/condor_ce_apel_partial.sh'),
@@ -68,12 +68,12 @@ prefix '/software/components/filecopy/services/';
 
 include 'components/dirperm/config';
 
-prefix "/software/components/dirperm/";
+prefix "/software/components/dirperm";
 
 'paths' = push(
     dict('path', '/var/log/apelparser.log',
         'owner', 'condor:condor',
-	'perm', '0664',
+        'perm', '0664',
         'type', 'f'
     )
 );

--- a/features/htcondor/client/condorce/apel.pan
+++ b/features/htcondor/client/condorce/apel.pan
@@ -1,0 +1,97 @@
+unique template features/htcondor/client/condorce/apel;
+
+
+#
+# By default the standard script in htcondor-ce-apel is used
+# if apel_partial is true a different script is used which
+# does not call apelclient and ssmsend. It is also possible to 
+# customize things further redefining apel_script
+#
+
+variable CONDOR_CONFIG = {
+    if(!is_defined(SELF['apel_partial']))
+        SELF['apel_partial'] = true;
+
+    if(!is_defined(SELF['apel_script'])){
+        if(SELF['apel_partial']){
+            SELF['apel_script'] = '/usr/share/condor-ce/condor_ce_apel_partial.sh';
+        }else{
+            SELF['apel_script']	= '/usr/share/condor-ce/condor_ce_apel.sh';
+        };
+    };
+
+    if(!is_defined(SELF['apel_output_dir']))
+        SELF['apel_output_dir'] = '/var/lib/condor-ce/apel';
+
+    SELF;
+};
+
+#
+# Apel config
+#
+
+include 'features/accounting/apel/parser_htcondorce';
+
+#
+# file in apel with the indications for the APEL cron defined in the schedd.
+#
+
+variable CONDOR_CONFIG = {
+
+   # Adding the condor bdii config
+   SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
+            'name', 'apel',
+            'contents', 'features/htcondor/templ/apel',
+            'base_path', SELF['ce_cfgdir'],
+        ));
+
+   SELF;
+};
+
+#
+# Script for partial publication.
+#
+
+include 'components/filecopy/config';
+
+prefix '/software/components/filecopy/services/';
+
+'{/usr/share/condor-ce/condor_ce_apel_partial.sh}' = dict(
+    'config', file_contents('features/htcondor/templ/condor_ce_apel_partial.sh'),
+    'perms', '0755',
+);
+
+
+#
+# apel dir and logfiles ownerships to condor
+#
+
+include 'components/dirperm/config';
+
+prefix "/software/components/dirperm/";
+
+'paths' = push(
+    dict('path', '/var/log/apelparser.log',
+        'owner', 'condor:condor',
+	'perm', '0664',
+        'type', 'f'
+    )
+);
+
+'paths' = push(
+    dict('path', CONDOR_CONFIG['apel_output_dir'],
+        'owner', 'condor:condor',
+        'perm', '0755',
+        'type', 'd'
+    )
+);
+
+
+#
+# Packages
+#
+include 'components/spma/config';
+
+prefix '/software/packages';
+
+'{htcondor-ce-apel}' = dict();

--- a/features/htcondor/client/condorce/auth.pan
+++ b/features/htcondor/client/condorce/auth.pan
@@ -2,6 +2,8 @@ unique template features/htcondor/client/condorce/auth;
 
 variable GLITE_GROUP = 'condor';
 
+variable GRIDMAPDIR_FILES_PERMS = true;
+
 include 'features/security/host_certs';
 
 include 'security/cas';
@@ -68,3 +70,22 @@ prefix '/software/components/lcmaps/config/0';
         "vomspoolaccount -> good|bad",
     ),
 ));
+
+include 'components/dirperm/config';
+
+prefix '/software/components/dirperm/';
+
+'paths' = push(
+    dict('path', '/var/log/glexec',
+        'owner', 'condor:condor',
+        'perm', '0775',
+        'type', 'd'
+    )
+);
+
+include 'components/filecopy/config';
+
+prefix '/software/components/filecopy/services/{/etc/grid-security/gsi-authz.conf}';
+
+'config' = 'globus_mapping /usr/lib64/liblcas_lcmaps_gt4_mapping.so lcmaps_callout' + "\n";
+'restart' = 'service condor-ce restart';

--- a/features/htcondor/client/condorce/auth.pan
+++ b/features/htcondor/client/condorce/auth.pan
@@ -40,22 +40,22 @@ prefix '/software/components/lcmaps/config/0';
 
 'module/vomspoolaccount' = dict(
     "path", "lcmaps_voms_poolaccount.mod",
-    "args", "-gridmapfile /etc/lcmaps/gridmapfile " + 
-            "-gridmapdir /etc/grid-security/gridmapdir " + 
+    "args", "-gridmapfile /etc/lcmaps/gridmapfile " +
+            "-gridmapdir /etc/grid-security/gridmapdir " +
             "-override_inconsistency " +
             "--add-primary-gid-from-mapped-account "
 );
 
 'module/vomslocalgroup' = dict(
     "path", "lcmaps_voms_localgroup.mod",
-    "args", "-groupmapfile /etc/lcmaps/groupmapfile " + 
-            "-mapmin 0 " + 
+    "args", "-groupmapfile /etc/lcmaps/groupmapfile " +
+            "-mapmin 0 " +
             "--map-to-secondary-groups",
 );
 
 'module/vomslocalaccount' = dict(
     "path", "lcmaps_voms_localaccount.mod",
-    "args", "-gridmapfile /etc/lcmaps/gridmapfile", 
+    "args", "-gridmapfile /etc/lcmaps/gridmapfile",
 );
 
 'module/good' = dict("path", "lcmaps_dummy_good.mod");
@@ -73,7 +73,7 @@ prefix '/software/components/lcmaps/config/0';
 
 include 'components/dirperm/config';
 
-prefix '/software/components/dirperm/';
+prefix '/software/components/dirperm';
 
 'paths' = push(
     dict('path', '/var/log/glexec',

--- a/features/htcondor/client/condorce/auth.pan
+++ b/features/htcondor/client/condorce/auth.pan
@@ -1,0 +1,70 @@
+unique template features/htcondor/client/condorce/auth;
+
+variable GLITE_GROUP = 'condor';
+
+include 'features/security/host_certs';
+
+include 'security/cas';
+
+include 'features/lcmaps/base';
+
+include 'features/lcas/base';
+
+include 'features/fetch-crl/config';
+
+include 'features/mkgridmap/standard';
+
+include 'components/spma/config';
+prefix '/software/packages';
+
+'{lcas-lcmaps-gt4-interface}' = dict();
+
+variable CONDORCE_LCMAPS_DEBUG ?= 0;
+
+include 'components/sysconfig/config';
+prefix '/software/components/sysconfig/files/condor-ce';
+
+'LCMAPS_DEBUG_LEVEL' = to_string(CONDORCE_LCMAPS_DEBUG);
+'LLGT_LIFT_PRIVILEGED_PROTECTION' = '1';
+'LCMAPS_LOG_FILE' = '/var/log/glexec/lcmaps.log';
+'LCMAPS_DB_FILE' = '/etc/lcmaps/lcmaps.db';
+'epilogue' = 'export LCMAPS_DEBUG_LEVEL LCMAPS_LOG_FILE';
+
+include 'components/lcmaps/config';
+prefix '/software/components/lcmaps/config/0';
+
+# Just erase everything else. There may be a better way but for the moment this is simpler....
+'module' = dict();
+
+'module/vomspoolaccount' = dict(
+    "path", "lcmaps_voms_poolaccount.mod",
+    "args", "-gridmapfile /etc/lcmaps/gridmapfile " + 
+            "-gridmapdir /etc/grid-security/gridmapdir " + 
+            "-override_inconsistency " +
+            "--add-primary-gid-from-mapped-account "
+);
+
+'module/vomslocalgroup' = dict(
+    "path", "lcmaps_voms_localgroup.mod",
+    "args", "-groupmapfile /etc/lcmaps/groupmapfile " + 
+            "-mapmin 0 " + 
+            "--map-to-secondary-groups",
+);
+
+'module/vomslocalaccount' = dict(
+    "path", "lcmaps_voms_localaccount.mod",
+    "args", "-gridmapfile /etc/lcmaps/gridmapfile", 
+);
+
+'module/good' = dict("path", "lcmaps_dummy_good.mod");
+
+'module/bad' = dict("path", "lcmaps_dummy_bad.mod");
+
+'policies' = list(dict(
+    'name', "authorize_only",
+    "ruleset", list(
+        "vomslocalgroup -> vomslocalaccount",
+        "vomslocalaccount -> good | vomspoolaccount",
+        "vomspoolaccount -> good|bad",
+    ),
+));

--- a/features/htcondor/client/condorce/bdii.pan
+++ b/features/htcondor/client/condorce/bdii.pan
@@ -6,13 +6,13 @@ include 'components/spma/config';
 
 variable CONDOR_CONFIG = {
 
-   # Adding the condor bdii config
-   SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
-            'name', 'bdii',
-            'contents', 'features/htcondor/templ/bdii',
-        ));
+    # Adding the condor bdii config
+    SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
+        'name', 'bdii',
+        'contents', 'features/htcondor/templ/bdii',
+    ));
 
-   SELF;
+    SELF;
 };
 
 

--- a/features/htcondor/client/condorce/bdii.pan
+++ b/features/htcondor/client/condorce/bdii.pan
@@ -1,0 +1,36 @@
+unique template features/htcondor/client/condorce/bdii;
+
+include 'components/spma/config';
+
+'/software/packages/{htcondor-ce-bdii}' = dict();
+
+variable CONDOR_CONFIG = {
+
+   # Adding the condor bdii config
+   SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
+            'name', 'bdii',
+            'contents', 'features/htcondor/templ/bdii',
+        ));
+
+   SELF;
+};
+
+
+#Changing the default as the current provider has no caching
+variable BDII_BREATHE_TIME ?= 600;
+
+include 'personality/bdii/service';
+
+# Also build queue names (required by CE GIP configuration) if not done as part of the client configuration
+include if ( LRMS_SERVER_HOST != FULL_HOSTNAME )
+    if_exists("features/" + CE_BATCH_NAME + "/server/build-queue-list");
+
+
+include 'components/gip2/config';
+
+prefix '/software/components/gip2';
+
+'external' = push(escape('/var/lib/bdii/gip/provider/htcondor-ce-provider'));
+
+'provider/htcondor-ce-provider-glue1' = file_contents('features/htcondor/templ/htcondor-ce-provider-glue1');
+

--- a/features/htcondor/client/condorce/config.pan
+++ b/features/htcondor/client/condorce/config.pan
@@ -1,0 +1,77 @@
+unique template features/htcondor/client/condorce/config;
+
+include 'features/htcondor/client/condorce/params';
+
+variable CONDOR_CONFIG = {
+
+   # Adding the file router configuration
+   SELF['cfgfiles'] = append(SELF['cfgfiles'], dict( 
+            'name', 'router', 
+            'contents', 'features/htcondor/templ/router',
+            'base_path', SELF['ce_cfgdir'],
+        ));
+
+   # The bdii publication point(s)
+   SELF['bdii_active'] = (
+       (!is_defined(SELF['resource_bdii'])) ||
+       (index(FULL_HOSTNAME, SELF['resource_bdii']) >= 0)
+   ); 
+
+    
+   SELF;
+};
+
+
+
+include 'components/filecopy/config';
+'/software/components/filecopy/services' = {
+
+# ... the file router hook 
+    SELF[escape(CONDOR_CONFIG['ce_cfgdir'] + '/hook.py')] = dict(
+
+        'config', file_contents(CONDOR_CONFIG['router_hook']),
+        'perms', '0755',
+        'restart', 'service condor-ce restart',
+    );
+
+# ... and the mapping file
+    content = create('features/htcondor/templ/condor_mapfile');
+
+    SELF[escape(CONDOR_CONFIG['ce_cfgdir'] + '/condor_mapfile')] = dict(
+
+        'config', content['text'],
+        'perms', '0644',
+        'restart', 'service condor-ce restart',
+    );        
+
+    SELF;
+};
+
+# TODO: add condor-ce to the restart
+
+include 'components/spma/config';
+
+prefix '/software/packages';
+'{htcondor-ce}' = dict();
+'{htcondor-ce-condor}' = dict();
+'{htcondor-ce-client}' = dict();
+
+
+include 'components/systemd/config';
+
+'/software/components/systemd/unit/{condor-ce}' = dict();
+
+
+include 'users/glite';
+
+include 'features/grid/dirperms';
+
+include if(CONDOR_CONFIG['bdii_active']) 'features/htcondor/client/condorce/bdii';
+
+include 'features/globus/sysconfig';
+
+include 'features/edg/sysconfig';
+
+include 'features/htcondor/client/condorce/auth';
+
+include 'features/htcondor/client/condorce/apel';

--- a/features/htcondor/client/condorce/config.pan
+++ b/features/htcondor/client/condorce/config.pan
@@ -4,21 +4,21 @@ include 'features/htcondor/client/condorce/params';
 
 variable CONDOR_CONFIG = {
 
-   # Adding the file router configuration
-   SELF['cfgfiles'] = append(SELF['cfgfiles'], dict( 
-            'name', 'router', 
-            'contents', 'features/htcondor/templ/router',
-            'base_path', SELF['ce_cfgdir'],
-        ));
+    # Adding the file router configuration
+    SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
+        'name', 'router',
+        'contents', 'features/htcondor/templ/router',
+        'base_path', SELF['ce_cfgdir'],
+    ));
 
-   # The bdii publication point(s)
-   SELF['bdii_active'] = (
-       (!is_defined(SELF['resource_bdii'])) ||
-       (index(FULL_HOSTNAME, SELF['resource_bdii']) >= 0)
-   ); 
+    # The bdii publication point(s)
+    SELF['bdii_active'] = (
+        (!is_defined(SELF['resource_bdii'])) ||
+        (index(FULL_HOSTNAME, SELF['resource_bdii']) >= 0)
+    );
 
-    
-   SELF;
+
+    SELF;
 };
 
 
@@ -26,7 +26,7 @@ variable CONDOR_CONFIG = {
 include 'components/filecopy/config';
 '/software/components/filecopy/services' = {
 
-# ... the file router hook 
+# ... the file router hook
     SELF[escape(CONDOR_CONFIG['ce_cfgdir'] + '/hook.py')] = dict(
 
         'config', file_contents(CONDOR_CONFIG['router_hook']),
@@ -42,7 +42,7 @@ include 'components/filecopy/config';
         'config', content['text'],
         'perms', '0644',
         'restart', 'service condor-ce restart',
-    );        
+    );
 
     SELF;
 };

--- a/features/htcondor/client/condorce/params.pan
+++ b/features/htcondor/client/condorce/params.pan
@@ -15,12 +15,15 @@ variable CONDOR_CONFIG = {
     if(!is_defined(SELF['mapping']))
         SELF['mapping'] = dict();
 
+    if(!is_defined(SELF['cert_dns']) || !is_defined(SELF['cert_dns'][FULL_HOSTNAME]))
+        error("Missing certificate DN for " + FULL_HOSTNAME + ": CONDOR_CONFIG['cert_dns']['" + FULL_HOSTNAME + "']");
+
     # implement some default mapping rules.
     # Note that the rules are written in the file in the lexicographic order
     mapping_defaults = dict(
         '10_daemon', dict(
              'type', 'GSI', 
-             'regex', '"^/O=GRID-FR/C=FR/O=CNRS/OU=.*/CN=' + FULL_HOSTNAME + '$"',
+             'regex', '"^' + SELF['cert_dns'][FULL_HOSTNAME] + '$"',
              'result', FULL_HOSTNAME + '@daemon.htcondor.org'
         ),
 

--- a/features/htcondor/client/condorce/params.pan
+++ b/features/htcondor/client/condorce/params.pan
@@ -1,0 +1,58 @@
+unique template features/htcondor/client/condorce/params;
+
+variable GLITE_LOCATION = '/usr';
+variable MKGRIDMAP_BIN ?= '/usr/sbin/';
+
+variable CONDOR_CONFIG = {
+
+    # defining a config dir for the condor-ce
+    if(!is_defined(SELF['ce_cfgdir']))
+        SELF['ce_cfgdir'] = '/etc/condor-ce';
+
+    if(!is_defined(SELF['router_hook']))
+        SELF['router_hook'] = 'features/htcondor/templ/hook.py';
+
+    if(!is_defined(SELF['mapping']))
+        SELF['mapping'] = dict();
+
+    # implement some default mapping rules.
+    # Note that the rules are written in the file in the lexicographic order
+    mapping_defaults = dict(
+        '10_daemon', dict(
+             'type', 'GSI', 
+             'regex', '"^/O=GRID-FR/C=FR/O=CNRS/OU=.*/CN=' + FULL_HOSTNAME + '$"',
+             'result', FULL_HOSTNAME + '@daemon.htcondor.org'
+        ),
+
+        '20_mapping', dict(
+             'type', 'GSI', 
+             'regex', '(.*)',
+             'result', 'GSS_ASSIST_GRIDMAP'
+        ),
+
+        '30_unampped', dict(
+             'type', 'GSI',
+             'regex', '"(/CN=[-.A-Za-z0-9/= ]+)"',
+             'result', '\1@unamapped.htcondor.org'
+        ),
+
+        '40_anon', dict(
+             'type', 'CLAIMTOBE',
+             'regex', '.*',
+             'result', 'anonymous@claimtobe'
+        ),
+
+        '50_fs', dict(
+             'type', 'FS',
+             'regex', '(.*)',
+             'result', '\1'
+        ),
+
+    );
+
+    foreach(i; rule; mapping_defaults)
+        if(!is_defined(SELF['mapping'][i]))
+            SELF['mapping'][i] = rule;
+       
+    SELF;
+};

--- a/features/htcondor/client/condorce/params.pan
+++ b/features/htcondor/client/condorce/params.pan
@@ -22,33 +22,33 @@ variable CONDOR_CONFIG = {
     # Note that the rules are written in the file in the lexicographic order
     mapping_defaults = dict(
         '10_daemon', dict(
-             'type', 'GSI', 
-             'regex', '"^' + SELF['cert_dns'][FULL_HOSTNAME] + '$"',
-             'result', FULL_HOSTNAME + '@daemon.htcondor.org'
+            'type', 'GSI',
+            'regex', '"^' + SELF['cert_dns'][FULL_HOSTNAME] + '$"',
+            'result', FULL_HOSTNAME + '@daemon.htcondor.org'
         ),
 
         '20_mapping', dict(
-             'type', 'GSI', 
-             'regex', '(.*)',
-             'result', 'GSS_ASSIST_GRIDMAP'
+            'type', 'GSI',
+            'regex', '(.*)',
+            'result', 'GSS_ASSIST_GRIDMAP'
         ),
 
         '30_unampped', dict(
-             'type', 'GSI',
-             'regex', '"(/CN=[-.A-Za-z0-9/= ]+)"',
-             'result', '\1@unamapped.htcondor.org'
+            'type', 'GSI',
+            'regex', '"(/CN=[-.A-Za-z0-9/= ]+)"',
+            'result', '\1@unamapped.htcondor.org'
         ),
 
         '40_anon', dict(
-             'type', 'CLAIMTOBE',
-             'regex', '.*',
-             'result', 'anonymous@claimtobe'
+            'type', 'CLAIMTOBE',
+            'regex', '.*',
+            'result', 'anonymous@claimtobe'
         ),
 
         '50_fs', dict(
-             'type', 'FS',
-             'regex', '(.*)',
-             'result', '\1'
+            'type', 'FS',
+            'regex', '(.*)',
+            'result', '\1'
         ),
 
     );
@@ -56,6 +56,6 @@ variable CONDOR_CONFIG = {
     foreach(i; rule; mapping_defaults)
         if(!is_defined(SELF['mapping'][i]))
             SELF['mapping'][i] = rule;
-       
+
     SELF;
 };

--- a/features/htcondor/client/creamce.pan
+++ b/features/htcondor/client/creamce.pan
@@ -1,0 +1,41 @@
+unique template features/htcondor/client/creamce;
+
+variable CONDOR_CONFIG = {
+
+    if(!is_defined(SELF['queue_superusers_list'])){
+        SELF['queue_superusers_list'] = 'tomcat';
+    };
+
+    SELF;
+};
+
+
+variable BLPARSER_WITH_UPDATER_NOTIFIER = true;
+
+# Fixme: a bug in the blah RPM
+variable HTCONDOR_FIX_BLAH ?= true;
+include if(HTCONDOR_FIX_BLAH) 'features/htcondor/client/fix-blah';
+
+include 'components/dirperm/config';
+
+'/software/components/dirperm/paths' = push(
+    dict(
+        'path', '/var/glite/',
+        'type', 'd',
+        'owner', 'glite:tomcat',
+        'perm', '775'
+    )
+);
+
+'/software/components/dirperm/paths' = push(
+    dict(
+        'path', '/var/glite/blah',
+        'type', 'd',
+        'owner', 'tomcat',
+        'perm', '775'
+    )
+);
+
+include 'components/chkconfig/config';
+
+'/software/components/chkconfig/service/glite-ce-blah-parser' = dict('on', '', 'startstop', true);

--- a/features/htcondor/client/job-transform.pan
+++ b/features/htcondor/client/job-transform.pan
@@ -14,7 +14,7 @@ variable CONDOR_CONFIG = {
             SELF['job-transform'] = dict();
         };
 
-        SELF['job-transform']['LeaveInQueue'] = format(CONDOR_REMOVE_REMOVED_FUNCTION, CONDOR_REMOVE_REMOVED_DELAY); 
+        SELF['job-transform']['LeaveInQueue'] = format(CONDOR_REMOVE_REMOVED_FUNCTION, CONDOR_REMOVE_REMOVED_DELAY);
 
     };
 

--- a/features/htcondor/client/job-transform.pan
+++ b/features/htcondor/client/job-transform.pan
@@ -1,0 +1,30 @@
+unique template features/htcondor/client/job-transform;
+
+variable CONDOR_REMOVE_REMOVED ?= false;
+variable CONDOR_REMOVE_REMOVED_DELAY ?= '2*3600';
+variable CONDOR_REMOVE_REMOVED_FUNCTION = <<EOF;
+    copy_LeaveJobInQueue = "SubmitterLeaveJobInQueue";
+    set_LeaveJobInQueue = (JobStatus == 3 && (time() - EnteredCurrentStatus) > %s) ? False : SubmitterLeaveJobInQueue
+EOF
+
+variable CONDOR_CONFIG = {
+    if(CONDOR_REMOVE_REMOVED){
+
+        if(!is_defined(SELF['job-transform'])){
+            SELF['job-transform'] = dict();
+        };
+
+        SELF['job-transform']['LeaveInQueue'] = format(CONDOR_REMOVE_REMOVED_FUNCTION, CONDOR_REMOVE_REMOVED_DELAY); 
+
+    };
+
+    if(is_defined(SELF['job-transform']) && length(SELF['job-transform']) > 0){
+        SELF['cfgfiles'] = append(SELF['cfgfiles'], dict(
+            'name', 'job-transform',
+            'contents', 'features/htcondor/templ/job-transform',
+        ));
+    };
+
+    SELF;
+};
+

--- a/features/htcondor/client/worker.pan
+++ b/features/htcondor/client/worker.pan
@@ -50,9 +50,9 @@ include 'components/filecopy/config';
 '/software/components/filecopy/services' = {
     if(is_defined(CONDOR_CONFIG['user_wrapper']))
         SELF[escape(CONDOR_CONFIG['user_wrapper']['path'])] = dict(
-             'config', CONDOR_CONFIG['user_wrapper']['contents'],
-             'perms', '0755',
+            'config', CONDOR_CONFIG['user_wrapper']['contents'],
+            'perms', '0755',
         );
-    
+
     SELF;
 };

--- a/features/htcondor/client/worker.pan
+++ b/features/htcondor/client/worker.pan
@@ -10,18 +10,24 @@ variable CONDOR_CONFIG = {
         append(file_list, 'mic')
     };
 
-    if (is_defined(SELF['user_wrapper'])){
-        if(!is_defined(SELF['user_wrapper']['path'])){
+
+    # User wrapper is required by the condorce config (for getting the env)
+    # we leave the possibility to change it or disable it.
+    if(!is_defined(SELF['use_user_wrapper']))
+        SELF['use_user_wrapper'] = true;
+
+    if (SELF['use_user_wrapper'] || is_defined(SELF['user_wrapper'])){
+        if(!is_defined(SELF['user_wrapper']))
+            SELF['user_wrapper'] = dict();
+
+        if(!is_defined(SELF['user_wrapper']['path']))
             SELF['user_wrapper']['path'] = '/etc/condor/user_wrapper.sh';
-        };
 
-        if(!is_defined(SELF['user_wrapper']['templ'])){
-            SELF['user_wrapper']['templ'] = 'features/htcondor/client/user_wrapper.sh';
-        };
+        if(!is_defined(SELF['user_wrapper']['templ']))
+            SELF['user_wrapper']['templ'] = 'features/htcondor/templ/user_wrapper.sh';
 
-        if(!is_defined(SELF['user_wrapper']['contents'])){
+        if(!is_defined(SELF['user_wrapper']['contents']))
             SELF['user_wrapper']['contents'] = file_contents(SELF['user_wrapper']['templ']);
-        };
     };
 
 
@@ -42,11 +48,11 @@ variable CONDOR_CONFIG = {
 
 include 'components/filecopy/config';
 '/software/components/filecopy/services' = {
-    if(is_defined(CONDOR_CONFIG['user_wrapper'])){
+    if(is_defined(CONDOR_CONFIG['user_wrapper']))
         SELF[escape(CONDOR_CONFIG['user_wrapper']['path'])] = dict(
              'config', CONDOR_CONFIG['user_wrapper']['contents'],
              'perms', '0755',
         );
-    };
+    
     SELF;
 };

--- a/features/htcondor/condorce.pan
+++ b/features/htcondor/condorce.pan
@@ -1,0 +1,14 @@
+unique template features/htcondor/condorce;
+
+include if(
+    (is_defined(LRMS_SERVER) && (FULL_HOSTNAME == LRMS_SERVER)) ||
+    (is_defined(CONDOR_CONFIG['host']) && (FULL_HOSTNAME == CONDOR_CONFIG['host'])) ||
+    (is_defined(CONDOR_CONFIG['hosts']) && (index(FULL_HOSTNAME, CONDOR_CONFIG['hosts']) >= 0))
+){
+
+    'features/htcondor/server/service';
+
+}else{
+
+    'features/htcondor/client/service';
+};

--- a/features/htcondor/config.pan
+++ b/features/htcondor/config.pan
@@ -64,7 +64,7 @@ include 'components/filecopy/config';
         if (!is_defined(CONDOR_CONFIG['intel_mic_discovery'])){
             intel_mic_discovery = file_contents('features/htcondor/templ/condor_mic_discovery');
         }else{
-            intel_mic_discovery = CONDOR_CONFIG['intel_mic_discovery']; 
+            intel_mic_discovery = CONDOR_CONFIG['intel_mic_discovery'];
         };
 
         SELF[escape('/usr/libexec/condor/condor_mic_discovery')] = dict(

--- a/features/htcondor/config.pan
+++ b/features/htcondor/config.pan
@@ -62,10 +62,13 @@ include 'components/filecopy/config';
 
     if (CONDOR_CONFIG['intel_mic']){
         if (!is_defined(CONDOR_CONFIG['intel_mic_discovery'])){
-            CONDOR_CONFIG['intel_mic_discovery'] = file_contents('features/htcondor/templ/condor_mic_discovery');
+            intel_mic_discovery = file_contents('features/htcondor/templ/condor_mic_discovery');
+        }else{
+            intel_mic_discovery = CONDOR_CONFIG['intel_mic_discovery']; 
         };
+
         SELF[escape('/usr/libexec/condor/condor_mic_discovery')] = dict(
-            'config', CONDOR_CONFIG['intel_mic_discovery'],
+            'config', intel_mic_discovery,
             'backup', false,
             'perms', '0775',
         );

--- a/features/htcondor/params.pan
+++ b/features/htcondor/params.pan
@@ -68,10 +68,13 @@ variable CONDOR_CONFIG = {
             error('No attribute "name" defined for CONDOR_CONFIG["cfgfiles"]["' + to_string(i) + '"]');
         };
 
+        if (!is_defined(file['base_path']))
+            file['base_path'] = SELF['cfgdir'];
+
         if (!is_defined(file['path'])) {
             file['path'] = format(
                 "%s/config.d/%s.%s.%s.conf",
-                SELF['cfgdir'], SELF['cfgprefix'], to_string(i), file['name']
+                file['base_path'], SELF['cfgprefix'], to_string(i), file['name']
             );
         };
 

--- a/features/htcondor/server/groups.pan
+++ b/features/htcondor/server/groups.pan
@@ -55,6 +55,11 @@ variable CONDOR_CONFIG = {
         SELF['group_defaults']['quota'] = 0.1;
     };
 
+    # By default, we let GROUP_SORT_EXPR as defined
+    if (!is_defined(SELF['group_defaults']['boost_multicore'])) {
+      SELF['group_defaults']['boost_multicore'] = false;
+    };
+
     # Now build the groups structure
     foreach (i; group; SELF['groups']) {
         if (!is_defined(group['static'])) {

--- a/features/htcondor/server/groups.pan
+++ b/features/htcondor/server/groups.pan
@@ -57,7 +57,7 @@ variable CONDOR_CONFIG = {
 
     # By default, we let GROUP_SORT_EXPR as defined
     if (!is_defined(SELF['group_defaults']['boost_multicore'])) {
-      SELF['group_defaults']['boost_multicore'] = false;
+        SELF['group_defaults']['boost_multicore'] = false;
     };
 
     # Now build the groups structure

--- a/features/htcondor/templ/apel.pan
+++ b/features/htcondor/templ/apel.pan
@@ -1,0 +1,28 @@
+structure template features/htcondor/templ/apel;
+
+'text' = {
+
+    txt = 'APEL_CE_HOST = ' + FULL_HOSTNAME + "\n";
+    txt = txt + 'APEL_BATCH_HOST = ' + CONDOR_CONFIG['hosts'][0] + "\n";
+    txt = txt + <<EOF;
+
+# The CE_ID is the CE, the port, and the batch system,
+# ending with -condor to show the type of batch system.
+APEL_CE_ID = $(APEL_CE_HOST):$(PORT)/$(APEL_BATCH_HOST)-condor
+
+EOF
+
+   txt = txt + 'APEL_OUTPUT_DIR = ' + CONDOR_CONFIG['apel_output_dir'] + "\n";
+   txt = txt + <<EOF;
+
+# This is cheating ...
+APEL_SCALING_ATTR = 1
+
+# Modify the apel executable if needed.
+EOF
+
+    txt = txt + 'SCHEDD_CRON_APEL_EXECUTABLE = ' + CONDOR_CONFIG['apel_script'] + "\n";
+
+    txt;
+
+};

--- a/features/htcondor/templ/apel.pan
+++ b/features/htcondor/templ/apel.pan
@@ -12,8 +12,8 @@ APEL_CE_ID = $(APEL_CE_HOST):$(PORT)/$(APEL_BATCH_HOST)-condor
 
 EOF
 
-   txt = txt + 'APEL_OUTPUT_DIR = ' + CONDOR_CONFIG['apel_output_dir'] + "\n";
-   txt = txt + <<EOF;
+    txt = txt + 'APEL_OUTPUT_DIR = ' + CONDOR_CONFIG['apel_output_dir'] + "\n";
+    txt = txt + <<EOF;
 
 # This is cheating ...
 APEL_SCALING_ATTR = 1

--- a/features/htcondor/templ/bdii.pan
+++ b/features/htcondor/templ/bdii.pan
@@ -1,0 +1,18 @@
+structure template features/htcondor/templ/bdii;
+
+'text' = {
+
+    vos = replace('\[ ', '', replace(' \]', '', to_string(VOS)));
+
+    txt = "HTCONDORCE_VONames = " + vos + "\n";
+    
+    txt = txt + "HTCONDORCE_SiteName = " + CONDOR_CONFIG['site_name'] + "\n";
+
+    txt = txt + "HTCONDORCE_SPEC = [ specfp2000 = " + CE_SF00 + "; hep_spec06 = " + CE_HEPSPEC06 + "; specint2000 = " + CE_SI00 + " ]\n";
+
+    txt = txt + "HTCONDORCE_CORES = 16\n";
+
+    txt = txt + "GLUE2DomainID = " + CONDOR_CONFIG['site_name'] + "\n";
+
+    txt;
+};

--- a/features/htcondor/templ/bdii.pan
+++ b/features/htcondor/templ/bdii.pan
@@ -5,10 +5,11 @@ structure template features/htcondor/templ/bdii;
     vos = replace('\[ ', '', replace(' \]', '', to_string(VOS)));
 
     txt = "HTCONDORCE_VONames = " + vos + "\n";
-    
+
     txt = txt + "HTCONDORCE_SiteName = " + CONDOR_CONFIG['site_name'] + "\n";
 
-    txt = txt + "HTCONDORCE_SPEC = [ specfp2000 = " + CE_SF00 + "; hep_spec06 = " + CE_HEPSPEC06 + "; specint2000 = " + CE_SI00 + " ]\n";
+    txt = txt + "HTCONDORCE_SPEC = [ specfp2000 = " + CE_SF00 + "; hep_spec06 = " +
+        CE_HEPSPEC06 + "; specint2000 = " + CE_SI00 + " ]\n";
 
     txt = txt + "HTCONDORCE_CORES = 16\n";
 

--- a/features/htcondor/templ/condor_ce_apel_partial.sh
+++ b/features/htcondor/templ/condor_ce_apel_partial.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# sjones@hep.ph.liv.ac.uk, 2019
+# Run the processes of an HTCondor-CE + HTCondor accounting run
+
+/usr/share/condor-ce/condor_blah.sh       # Make the blah file (CE/Security data)
+/usr/share/condor-ce/condor_batch.sh      # Make the batch file (batch system job run times)
+/usr/bin/apelparser                       # Read the blah and batch files in

--- a/features/htcondor/templ/condor_ce_apel_partial.sh
+++ b/features/htcondor/templ/condor_ce_apel_partial.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-# sjones@hep.ph.liv.ac.uk, 2019
 # Run the processes of an HTCondor-CE + HTCondor accounting run
 
-/usr/share/condor-ce/condor_blah.sh       # Make the blah file (CE/Security data)
-/usr/share/condor-ce/condor_batch.sh      # Make the batch file (batch system job run times)
-/usr/bin/apelparser                       # Read the blah and batch files in
+#Clean up the env to use the condor history rather than the condor-ce's
+unset CONDOR_PARENT_ID SCHEDD_INTERFACE_VERSION CONDOR_PROCD_ADDRESS_BASE \
+    CONDOR_CONFIG CONDOR_INHERIT CONDOR_PROCD_ADDRESS
+
+/usr/share/condor-ce/condor_blah.sh # Make the blah file (CE/Security data)
+/usr/share/condor-ce/condor_batch.sh  # Make the batch file (batch system job run times)
+/usr/bin/apelparser # Read the blah and batch files in

--- a/features/htcondor/templ/condor_mapfile.pan
+++ b/features/htcondor/templ/condor_mapfile.pan
@@ -1,0 +1,11 @@
+structure template features/htcondor/templ/condor_mapfile;
+
+'text' = {
+    txt = '';
+
+    foreach(i; rule; CONDOR_CONFIG['mapping'])
+        if(!is_null(rule))
+            txt = txt + rule['type'] + ' ' + rule['regex'] + ' ' + rule['result'] + "\n";
+
+    txt;
+};

--- a/features/htcondor/templ/groups.pan
+++ b/features/htcondor/templ/groups.pan
@@ -50,6 +50,12 @@ structure template features/htcondor/templ/groups;
     };
     txt = txt + "\n";
 
+    if (CONDOR_CONFIG['group_defaults']['boost_multicore']) {
+      txt = txt + 'GROUP_SORT_EXPR = ifThenElse(AccountingGroup=?="<none>", 3.4e+38, ';
+      txt = txt + '  ifThenElse(RequestCpus == 8,ifThenElse(GroupQuota > 0,-2+GroupResourcesInUse/GroupQuota,-1), ';
+      txt = txt + '  ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 3.3e+38)))';
+    };
+
     txt;
 };
 

--- a/features/htcondor/templ/groups.pan
+++ b/features/htcondor/templ/groups.pan
@@ -51,9 +51,9 @@ structure template features/htcondor/templ/groups;
     txt = txt + "\n";
 
     if (CONDOR_CONFIG['group_defaults']['boost_multicore']) {
-      txt = txt + 'GROUP_SORT_EXPR = ifThenElse(AccountingGroup=?="<none>", 3.4e+38, ';
-      txt = txt + '  ifThenElse(RequestCpus == 8,ifThenElse(GroupQuota > 0,-2+GroupResourcesInUse/GroupQuota,-1), ';
-      txt = txt + '  ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 3.3e+38)))';
+        txt = txt + 'GROUP_SORT_EXPR = ifThenElse(AccountingGroup=?="<none>", 3.4e+38, ';
+        txt = txt + '  ifThenElse(RequestCpus == 8,ifThenElse(GroupQuota > 0,-2+GroupResourcesInUse/GroupQuota,-1), ';
+        txt = txt + '  ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 3.3e+38)))';
     };
 
     txt;

--- a/features/htcondor/templ/hook.py
+++ b/features/htcondor/templ/hook.py
@@ -6,7 +6,7 @@ the general set of rules '/etc/condor/groups_mapping.xml'.
 
 import fileinput
 import re
-import logging
+#import logging
 import xml.etree.ElementTree as ET
 
 MAX_CHAIN_DEPTH = 5
@@ -85,10 +85,14 @@ MATCH = MATCH.replace('"', '')
 
 LIMIT = mapping(MAPPER, 'limit', MATCH)
 
+ACCGRP = mapping(MAPPER, 'group', MATCH)
+
+OWNER = CLASSADS['Owner'].replace('"', '')
+
 if LIMIT != 'NONE':
     CLASSADS['ConcurrencyLimits'] = "\"%s\"" % LIMIT
-CLASSADS['AcctGroup'] = "\"%s\"" % mapping(MAPPER, 'group', MATCH)
-CLASSADS['AccountingGroup'] = CLASSADS['AcctGroup']
+CLASSADS['AcctGroup'] = "\"%s\"" % ACCGRP
+CLASSADS['AccountingGroup'] = "\"%s.%s\"" % (ACCGRP, OWNER)
 CLASSADS['AcctGroupUser'] = CLASSADS['Owner']
 CLASSADS['WNTag'] = "\"%s\"" % mapping(MAPPER, 'tag', MATCH)
 CLASSADS['PolicyGroup'] = "\"%s\"" % mapping(MAPPER, 'policy', MATCH)

--- a/features/htcondor/templ/hook.py
+++ b/features/htcondor/templ/hook.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python
+"""
+Hook executed at job routing. Inegrates the condor ce jobs with
+the general set of rules '/etc/condor/groups_mapping.xml'.
+"""
+
+import fileinput
+import re
+import logging
+import xml.etree.ElementTree as ET
+
+MAX_CHAIN_DEPTH = 5
+
+def get_classads():
+    """
+    Reads the list of classAds in stdinput and puts it in a dictionnary
+    """
+    ca_regex = re.compile(r'^\s*([^\[=\s]+)\s*=\s*(.+)$')
+
+    return {m.group(1) : m.group(2) for m in
+            [ca_regex.match(line) for line in fileinput.input()] if m}
+
+def load_mapper(rulesfile):
+    """
+    Load the rules for mapping
+    """
+    rules = []
+
+    xml = ET.parse(rulesfile)
+
+    for rule in xml.getroot():
+        rule_dict = rule.__dict__['attrib']
+        rule_dict['tag'] = rule.__dict__['tag']
+        rules.append(rule_dict)
+
+    return rules
+
+def mapping(rules, tag, target, depth=0):
+    """
+    Performs the matching of one target string with the set of rules in rules
+    """
+    if depth > MAX_CHAIN_DEPTH:
+        raise Exception("Max depth reached matching target string %s and tag %s with rules %s" %
+                        target, tag, rules)
+
+    for rule in rules:
+        if rule['tag'] == tag:
+            if 'chain' in rule:
+                target = mapping(target, rules, rule['chain'], depth + 1)
+
+            if rule['match'][-1] != '$':
+                rule['match'] = rule['match'] + '.*$'
+
+            regex = re.compile(rule['match'])
+            if regex.match(target):
+                return regex.sub(rule['result'].replace('$', '\\'), target)
+
+    if depth > 0:
+        return target
+
+    raise ValueError("target %s with tag %s cannot be matched by rules %s" % (target, tag, rules))
+
+
+logging.basicConfig(
+    format='%(asctime)s;%(message)s',
+    filename='/var/log/hook.log',
+    level=logging.INFO
+)
+
+MAPPER = load_mapper('/etc/condor/groups_mapping.xml')
+
+CLASSADS = get_classads()
+
+CLASSADS['CreamQueue'] = '"gridq"'
+
+CLASSADS['x509UserProxyVOName_Fmt'] = CLASSADS['x509UserProxyVOName']\
+                                      .replace('.', '_').replace('-', '_')
+
+MATCH_FMT = '(%(x509UserProxyVOName_Fmt)s,'
+MATCH_FMT += '%(x509UserProxyFirstFQAN)s,'
+MATCH_FMT += '%(x509UserProxyFirstFQAN)s,'
+MATCH_FMT += '%(CreamQueue)s)'
+
+MATCH = MATCH_FMT % CLASSADS
+
+MATCH = MATCH.replace('"', '')
+
+LIMIT = mapping(MAPPER, 'limit', MATCH)
+
+if LIMIT != 'NONE':
+    CLASSADS['ConcurrencyLimits'] = "\"%s\"" % LIMIT
+CLASSADS['AcctGroup'] = "\"%s\"" % mapping(MAPPER, 'group', MATCH)
+CLASSADS['AccountingGroup'] = CLASSADS['AcctGroup']
+CLASSADS['AcctGroupUser'] = CLASSADS['Owner']
+CLASSADS['WNTag'] = "\"%s\"" % mapping(MAPPER, 'tag', MATCH)
+CLASSADS['PolicyGroup'] = "\"%s\"" % mapping(MAPPER, 'policy', MATCH)
+CLASSADS['MyVOName'] = CLASSADS['x509UserProxyVOName']
+CLASSADS['MyProxySubject'] = CLASSADS['x509userproxysubject']
+CLASSADS['MyFQAN'] = CLASSADS['x509UserProxyFirstFQAN']
+
+## Uncomment this if you want to have logging
+##logging.info(CLASSADS)
+
+for name, value in CLASSADS.items():
+    print "%s = %s" % (name, value)

--- a/features/htcondor/templ/hook.py
+++ b/features/htcondor/templ/hook.py
@@ -60,18 +60,16 @@ def mapping(rules, tag, target, depth=0):
 
     raise ValueError("target %s with tag %s cannot be matched by rules %s" % (target, tag, rules))
 
-
-logging.basicConfig(
-    format='%(asctime)s;%(message)s',
-    filename='/var/log/hook.log',
-    level=logging.INFO
-)
+# Uncomment this if you want to have logging for debug.
+#logging.basicConfig(
+#    format='%(asctime)s;%(message)s',
+#    filename='/var/tmp/hook.log',
+#    level=logging.INFO
+#)
 
 MAPPER = load_mapper('/etc/condor/groups_mapping.xml')
 
 CLASSADS = get_classads()
-
-CLASSADS['CreamQueue'] = '"gridq"'
 
 CLASSADS['x509UserProxyVOName_Fmt'] = CLASSADS['x509UserProxyVOName']\
                                       .replace('.', '_').replace('-', '_')
@@ -79,7 +77,7 @@ CLASSADS['x509UserProxyVOName_Fmt'] = CLASSADS['x509UserProxyVOName']\
 MATCH_FMT = '(%(x509UserProxyVOName_Fmt)s,'
 MATCH_FMT += '%(x509UserProxyFirstFQAN)s,'
 MATCH_FMT += '%(x509UserProxyFirstFQAN)s,'
-MATCH_FMT += '%(CreamQueue)s)'
+MATCH_FMT += 'condorce)'
 
 MATCH = MATCH_FMT % CLASSADS
 

--- a/features/htcondor/templ/htcondor-ce-provider-glue1
+++ b/features/htcondor/templ/htcondor-ce-provider-glue1
@@ -1,0 +1,283 @@
+#!/usr/bin/env python
+
+"""
+GLUE1 GIP provider for htcondor-CE.
+Minimal version with only static info
+"""
+
+# we cannot change the name of the script.
+# pylint: disable=invalid-name
+
+
+from __future__ import print_function
+import sys
+import os
+import time
+from socket import gethostname
+import htcondor
+import classad as ca
+
+
+GLUE1_CE_STATIC_LDIF = """
+dn: GlueCEUniqueID={endpointid}:9619/{central_manager}-condor,Mds-Vo-name=resource,o=grid
+GlueCEStateStatus: Production
+GlueCEPolicyPriority: 1
+GlueCEInfoJobManager: condor
+GlueCEInfoHostName: {endpointid}
+GlueCEUniqueID: {endpointid}:9619/{central_manager}-condor 
+GlueForeignKey: GlueClusterUniqueID=llrcream.in2p3.fr
+GlueCEInfoLRMSType: condor
+GlueCEImplementationName: HTCONDORCE
+GlueCEInfoGatekeeperPort: 9619
+GlueCECapability: CPUScalingReferenceSI00={si00}
+GlueSchemaVersionMajor: 1
+GlueCEInfoDataDir: unset
+{vos}GlueCEInfoContactString: {endpointid}:9619/{central_manager}-condor
+GlueSchemaVersionMinor: 3
+GlueCEPolicyPreemption: 0
+GlueInformationServiceURL: ldap://{endpointid}:2170/mds-vo-name=resource,
+ o=grid
+GlueCEHostingCluster: {endpointid}
+GlueCEInfoLRMSVersion: {condor_version}
+objectClass: GlueCETop
+objectClass: GlueCE
+objectClass: GlueCEAccessControlBase
+objectClass: GlueCEInfo
+objectClass: GlueCEPolicy
+objectClass: GlueCEState
+objectClass: GlueInformationService
+objectClass: GlueKey
+objectClass: GlueSchemaVersion
+GlueCEImplementationVersion: {ce_version}
+GlueCEPolicyMaxObtainableCPUTime: 0
+GlueCEInfoTotalCPUs: {cores}
+GlueCEPolicyMaxRunningJobs: {cores}
+GlueCEPolicyAssignedJobSlots
+GlueCEStateTotalJobs: 0
+GlueCEStateEstimatedResponseTime: 43200
+GlueCEStateFreeCPUs: {cores}
+GlueCEStateRunningJobs: 0
+GlueCEStateWaitingJobs: 0
+GlueCEStateWorstResponseTime: 259200
+GlueCEStateFreeJobSlots: 0
+
+"""
+
+GLUE1_CE_DYNAMIC_LDIF = """
+GlueCEStateTotalJobs: {jobs}
+GlueCEStateEstimatedResponseTime: 43200
+GlueCEStateFreeCPUs: {free}
+GlueCEStateRunningJobs: {running}
+GlueCEStateWaitingJobs: {idle}
+GlueCEStateWorstResponseTime: 259200
+GlueCEStateFreeJobSlots: {free}
+"""
+
+
+GLUE1_CLUSTER_LDIF = """
+dn: GlueClusterUniqueID={endpointid},Mds-Vo-name=resource,o=grid
+objectClass: GlueClusterTop
+objectClass: GlueCluster
+objectClass: GlueInformationService
+objectClass: GlueKey
+objectClass: GlueSchemaVersion
+GlueClusterService: {endpointid}:9619/{central_manager}-condor
+GlueSchemaVersionMinor: 3
+GlueForeignKey: GlueSiteUniqueID={site}
+GlueSchemaVersionMajor: 1
+GlueClusterName: {endpointid}
+GlueInformationServiceURL: ldap://{endpointid}:2170/mds-vo-name=resource,
+ o=grid
+GlueClusterUniqueID: {endpointid}
+
+"""
+
+# We have one subcluster per machine OS/arch
+GLUE1_SUBCLUSTER_LDIF = """
+dn: GlueSubClusterUniqueID={scname},
+  GlueClusterUniqueID={endpointid},Mds-Vo-name=resource,o=grid
+GlueSubClusterName: {scname}
+GlueHostOperatingSystemName: {name}
+GlueHostOperatingSystemRelease: {version}
+GlueChunkKey: GlueClusterUniqueID={endpointid}
+GlueHostArchitecturePlatformType: {arch}
+GlueHostBenchmarkSI00: {si00}
+GlueHostMainMemoryVirtualSize: {memory}
+GlueHostBenchmarkSF00: {sf00}
+GlueHostNetworkAdapterInboundIP: FALSE
+GlueSubClusterWNTmpDir: /tmp
+GlueSchemaVersionMajor: 1
+GlueSubClusterTmpDir: /tmp
+GlueHostNetworkAdapterOutboundIP: TRUE
+GlueSchemaVersionMinor: 3
+GlueInformationServiceURL: ldap://{endpointid}:2170/mds-vo-name=resource,
+ o=grid
+objectClass: GlueClusterTop
+objectClass: GlueSubCluster
+objectClass: GlueHostApplicationSoftware
+objectClass: GlueHostArchitecture
+objectClass: GlueHostBenchmark
+objectClass: GlueHostMainMemory
+objectClass: GlueHostOperatingSystem
+objectClass: GlueHostProcessor
+objectClass: GlueInformationService
+objectClass: GlueKey
+objectClass: GlueSchemaVersion
+GlueHostMainMemoryRAMSize: {memory}
+GlueSubClusterUniqueID: {scname}
+GlueHostArchitectureSMPSize: 2
+GlueSubClusterPhysicalCPUs: {cpus}
+GlueSubClusterLogicalCPUs: {cores}
+GlueHostProcessorOtherDescription: Cores={cpm},Benchmark={hep-spec06}-HEP-SPEC06
+
+"""
+
+GLUE1_LIFETIME = 100
+GLUE1_CACHE = '/var/tmp/htcondor-ce-provider-glue1-cache'
+
+def cache_expired(cache):
+    """
+    Test if a cache is expired (or missing)
+    :cache: cache file
+    """
+
+    if not os.path.exists(cache):
+        return True
+
+
+    max_age = htcondor.param.get('HTCONDORCE_GLUE1_LIFETIME') or GLUE1_LIFETIME
+    age = time.time() - os.path.getmtime(cache)
+
+    return age > max_age
+
+def static_ldif():
+    """
+    Get the static data about the cluster
+    """
+
+    # central manager (take the primary in case of HA)
+    central_manager = htcondor.param.get('COLLECTOR_HOST').split(' ')[0]
+
+    # site name
+    site = htcondor.param.get('GLUE2DomainID')
+    if not site:
+        sys.stderr.write("Error: GLUE2DomainID: not set\n")
+        sys.exit(1)
+
+    # Get VO Names
+    vonames = htcondor.param.get('HTCONDORCE_VONames')
+    if not vonames:
+        sys.stderr.write("Error: HTCONDORCE_VONames not set\n")
+        sys.exit(1)
+    vonames = vonames.split(',')
+
+
+    # Query collector for the machines availables
+    coll = htcondor.Collector()
+    machines = {}
+    subclusters = {}
+    specs = ca.ClassAd(htcondor.param.get('HTCONDORCE_SPEC')) or []
+    vos = ''
+    for vo in vonames:
+        vos += "GlueCEAccessControlBaseRule: VO:%s\n" % vo
+
+    totals = {
+        'site': site,
+        'central_manager': central_manager,
+        'endpointid': gethostname(),
+        'machines': 0,
+        'cores': 0,
+        'si00': specs['specint2000'],
+        'vos': vos,
+        'condor_version': '8.8.8',
+        'ce_version': '3.4.0'
+    }
+
+ 
+    for classad in coll.query(
+            htcondor.AdTypes.Startd, 'State=!="Owner"', [
+                'Arch', 'OpSys', 'OpSysMajorVer', 'OpSysName',
+                'DetectedCpus', 'DetectedMemory', 'Machine'
+            ]
+        ):
+
+        if (not classad.get('Machine')) or (classad['Machine'] in machines):
+            continue  # skip malformed ads and machines already counted
+
+        machines[classad['Machine']] = 1
+
+        try:
+            scname = "%s_%s_%s_%s" % (
+                gethostname(),
+                classad['OpSysName'],
+                classad['OpSysMajorVer'],
+                classad['Arch'].lower()
+            )
+
+            if scname not in subclusters:
+                subclusters[scname] = {
+                    'scname': scname,
+                    'arch': classad['Arch'].lower(),
+                    'name': classad['OpSysName'],
+                    'version': classad['OpSysMajorVer'],
+                    'endpointid': gethostname(),
+                    'machines': 0,
+                    'cpus': 0,
+                    'cores': 0,
+                    'totmemory': 0,
+                    'sf00': specs['specfp2000'],
+                    'si00': specs['specint2000'],
+                    'hep-spec06': specs['hep_spec06'],
+                }
+
+            subclusters[scname]['machines'] += 1
+            subclusters[scname]['cpus'] += 2 # Todo: do not assume 2 cpu per machine
+            subclusters[scname]['cores'] += classad['DetectedCpus']
+            subclusters[scname]['totmemory'] += classad['DetectedMemory']
+            totals['machines'] += 1
+            totals['cores'] += classad['DetectedCpus']
+
+        except KeyError, exc:
+            msg = "Malformed machine ad: Missing '{0}' attribute for {1}"\
+                   .format(exc, classad['Machine'])
+            sys.stderr.write(msg)
+
+    ldif_cache = GLUE1_CE_STATIC_LDIF.format(**totals) +\
+        GLUE1_CLUSTER_LDIF.format(**totals)
+
+    for scname, scluster in subclusters.items():
+        scluster['cpm'] = scluster['cores']/scluster['machines']
+        scluster['memory'] = scluster['totmemory']/scluster['cores']
+
+        ldif_cache += GLUE1_SUBCLUSTER_LDIF.format(**scluster)
+
+    return ldif_cache
+
+def write_cache(cache):
+    """
+    Write the cache file
+    """
+    ldif_cache = static_ldif()
+
+    with open(cache, 'w') as cachefh:
+        cachefh.write(ldif_cache)
+
+
+def main():
+    """
+    Main provider routine.
+    """
+
+    # Static data is cached.
+    cache = htcondor.param.get('HTCONDORCE_GLUE1_CACHE') or GLUE1_CACHE
+
+    if cache_expired(cache):
+        write_cache(cache)
+
+    with open(cache, 'r') as cachefh:
+        ldif = cachefh.read()
+
+    print(ldif)
+
+if __name__ == '__main__':
+    main()

--- a/features/htcondor/templ/job-transform.pan
+++ b/features/htcondor/templ/job-transform.pan
@@ -1,0 +1,23 @@
+structure template features/htcondor/templ/job-transform;
+
+'text' = {
+    fmtstr = "JOB_TRANSFORM_%s @=end\n[\n%s\n]\n@end\n";
+
+    txt = "";
+
+    txt = txt + 'JOB_TRANSFORM_NAMES =';
+
+    foreach (name; rule; CONDOR_CONFIG['job-transform']) {
+        txt = txt + ' ' + name;
+    };
+
+    txt = txt + "\n";
+
+    foreach (name; body; CONDOR_CONFIG['job-transform']) {
+        txt = txt + format(fmtstr, name, body)
+    };
+
+    txt = txt + "\n";
+
+    txt;
+};

--- a/features/htcondor/templ/quattor_cleaning_script.pan
+++ b/features/htcondor/templ/quattor_cleaning_script.pan
@@ -22,10 +22,11 @@ EOF
     cfg_glob = '';
 
     if(is_defined(CONDOR_CONFIG['cfgdir']))
-         cfg_glob = CONDOR_CONFIG['cfgdir'] + '/config.d/' + CONDOR_CONFIG['cfgprefix'] + '.*.conf';
+        cfg_glob = CONDOR_CONFIG['cfgdir'] + '/config.d/' + CONDOR_CONFIG['cfgprefix'] + '.*.conf';
 
     if(is_defined(CONDOR_CONFIG['ce_cfgdir']))
-         cfg_glob = cfg_glob + ' ' + CONDOR_CONFIG['ce_cfgdir'] + '/config.d/' + CONDOR_CONFIG['cfgprefix'] + '.*.conf ';
+        cfg_glob = cfg_glob + ' ' + CONDOR_CONFIG['ce_cfgdir'] + '/config.d/' +
+            CONDOR_CONFIG['cfgprefix'] + '.*.conf ';
 
     txt = txt + 'FILESLIST=$(ls ' + cfg_glob + ' 2>/dev/null)' + "\n";
 

--- a/features/htcondor/templ/quattor_cleaning_script.pan
+++ b/features/htcondor/templ/quattor_cleaning_script.pan
@@ -19,7 +19,15 @@ EOF
 
     txt = txt + 'EXPFILESLIST="' + filelist + '"' + "\n";
 
-    txt = txt + 'FILESLIST=$(ls ' + CONDOR_CONFIG['cfgdir'] + '/config.d/' + CONDOR_CONFIG['cfgprefix'] + '.*.conf 2>/dev/null)' + "\n";
+    cfg_glob = '';
+
+    if(is_defined(CONDOR_CONFIG['cfgdir']))
+         cfg_glob = CONDOR_CONFIG['cfgdir'] + '/config.d/' + CONDOR_CONFIG['cfgprefix'] + '.*.conf';
+
+    if(is_defined(CONDOR_CONFIG['ce_cfgdir']))
+         cfg_glob = cfg_glob + ' ' + CONDOR_CONFIG['ce_cfgdir'] + '/config.d/' + CONDOR_CONFIG['cfgprefix'] + '.*.conf ';
+
+    txt = txt + 'FILESLIST=$(ls ' + cfg_glob + ' 2>/dev/null)' + "\n";
 
     txt = txt + <<EOF;
 

--- a/features/htcondor/templ/router.pan
+++ b/features/htcondor/templ/router.pan
@@ -12,5 +12,12 @@ EOF
 
     txt = txt + "MyHook_HOOK_TRANSLATE_JOB = " + CONDOR_CONFIG['ce_cfgdir'] + '/hook.py' + "\n";
 
+    hosts = '';
+    foreach(i; h; CONDOR_CONFIG['hosts']){
+        hosts = hosts + " " + h + ":9618";
+    };
+
+    txt = txt + "JOB_ROUTER_SCHEDD2_POOL =" + hosts;
+
     txt;
 };

--- a/features/htcondor/templ/router.pan
+++ b/features/htcondor/templ/router.pan
@@ -1,0 +1,16 @@
+structure template features/htcondor/templ/router;
+
+'text' = {
+
+    txt = <<EOF;
+#SCHEDD_DEBUG = D_FULLDEBUG
+#JOB_ROUTER_DEBUG = D_FULLDEBUG
+
+JOB_ROUTER_HOOK_KEYWORD = MyHook
+EOF
+
+
+    txt = txt + "MyHook_HOOK_TRANSLATE_JOB = " + CONDOR_CONFIG['ce_cfgdir'] + '/hook.py' + "\n";
+
+    txt;
+};

--- a/features/htcondor/templ/security.pan
+++ b/features/htcondor/templ/security.pan
@@ -29,6 +29,12 @@ structure template features/htcondor/templ/security;
         sec_daemon_authentication_method = 'password';
     };
 
+    if(is_defined(CONDOR_CONFIG['delegate_job_gsi_credentials_lifetime'])){
+        delegate_job_gsi_credentials_lifetime = CONDOR_CONFIG['delegate_job_gsi_credentials_lifetime'];
+    }else{
+        delegate_job_gsi_credentials_lifetime = null;
+    };
+
     #building the string
     txt = "\nALLOW_WRITE = " + CONDOR_CONFIG['allow'] + "\n";
 
@@ -41,8 +47,12 @@ structure template features/htcondor/templ/security;
     txt = txt + "SEC_DAEMON_AUTHENTICATION = " + sec_daemon_authentication + "\n";
     txt = txt + "SEC_DAEMON_AUTHENTICATION_METHODS = " + sec_daemon_authentication_method + "\n";
     txt = txt + "SEC_CLIENT_AUTHENTICATION_METHODS = " + sec_client_authentication_method + "\n\n";
+    if(! is_null(delegate_job_gsi_credentials_lifetime)) {
+      txt = txt + "delegate_job_GSI_credentials_lifetime = " + to_string(delegate_job_gsi_credentials_lifetime) + "\n\n";
+    };
 
     txt = txt + "SEC_PASSWORD_FILE = " + CONDOR_CONFIG['pwd_file'];
+
 
     txt = txt + <<EOF;
 

--- a/features/htcondor/templ/security.pan
+++ b/features/htcondor/templ/security.pan
@@ -48,7 +48,8 @@ structure template features/htcondor/templ/security;
     txt = txt + "SEC_DAEMON_AUTHENTICATION_METHODS = " + sec_daemon_authentication_method + "\n";
     txt = txt + "SEC_CLIENT_AUTHENTICATION_METHODS = " + sec_client_authentication_method + "\n\n";
     if(! is_null(delegate_job_gsi_credentials_lifetime)) {
-      txt = txt + "delegate_job_GSI_credentials_lifetime = " + to_string(delegate_job_gsi_credentials_lifetime) + "\n\n";
+        txt = txt + "delegate_job_GSI_credentials_lifetime = " +
+            to_string(delegate_job_gsi_credentials_lifetime) + "\n\n";
     };
 
     txt = txt + "SEC_PASSWORD_FILE = " + CONDOR_CONFIG['pwd_file'];

--- a/features/htcondor/templ/user_wrapper.sh
+++ b/features/htcondor/templ/user_wrapper.sh
@@ -1,0 +1,9 @@
+#! /bin/bash                                                                                                                                                                                                
+
+routedBy=`grep RoutedBy $_CONDOR_JOB_AD|cut -d '"' -f 2`
+if [ "x$routedBy" == "xhtcondor-ce" ];
+then
+    . /etc/profile
+fi
+
+eval "$@"

--- a/features/mkgridmap/base.pan
+++ b/features/mkgridmap/base.pan
@@ -15,7 +15,7 @@ variable MKGRIDMAP_DEF_CONF ?= MKGRIDMAP_CONF_DIR + '/edg-mkgridmap.conf';
 
 # Update gridmap file every 30mn on a UI as it relies only on gridmap file
 # Run every 3 hours on services relying mainly on VOMS
-variable MKGRIDMAP_REFRESH_INTERVAL = if ( 
+variable MKGRIDMAP_REFRESH_INTERVAL = if (
     exists(GSISSH_SERVER_ENABLED) &&
     is_defined(GSISSH_SERVER_ENABLED) &&
     GSISSH_SERVER_ENABLED ) {
@@ -35,17 +35,17 @@ variable MKGRIDMAP_REFRESH_INTERVAL = if (
 #----------------------------------------------------------------------------
 include 'components/gridmapdir/config';
 
-"/software/components/gridmapdir/" = {
+"/software/components/gridmapdir" = {
 
     SELF['gridmapdir'] = SITE_DEF_GRIDMAPDIR;
-    
+
     # Shared gridmapdir, if enabled, is configured only on listed clients,
     # if a list is defined. If gridmapdir is NFS-shared, do not configure
     # the sharedGridmapdir property on the machine serving it.
     if ( is_defined(GRIDMAPDIR_SHARED_PATH) ) {
-        if ( 
+        if (
             ((GRIDMAPDIR_SHARED_SERVER != FULL_HOSTNAME) || !match(to_lowercase(GRIDMAPDIR_SHARED_PROTOCOL), '^nfs')) &&
-            (!is_defined(GRIDMAPDIR_SHARED_CLIENTS) || (index(FULL_HOSTNAME,GRIDMAPDIR_SHARED_CLIENTS) >= 0) )
+            (!is_defined(GRIDMAPDIR_SHARED_CLIENTS) || (index(FULL_HOSTNAME, GRIDMAPDIR_SHARED_CLIENTS) >= 0) )
         ) {
             SELF['sharedGridmapdir'] = GRIDMAPDIR_SHARED_PATH;
         };
@@ -69,12 +69,12 @@ include 'components/filecopy/config';
 
 '/software/components/filecopy/services' = {
     if(GRIDMAPDIR_FILES_PERMS){
-       
+
         script_name = '/etc/grid-security/mapdir-perms.sh';
-        
-        script = "#! /bin/bash\n" + 
-                 "chown root:" + GLITE_GROUP + " " + SITE_DEF_GRIDMAPDIR + "/*\n" +
-                 "chmod 660 " + SITE_DEF_GRIDMAPDIR + "/*\n";  
+
+        script = "#! /bin/bash\n" +
+            "chown root:" + GLITE_GROUP + " " + SITE_DEF_GRIDMAPDIR + "/*\n" +
+            "chmod 660 " + SITE_DEF_GRIDMAPDIR + "/*\n";
 
         SELF[escape(script_name)] = dict(
             'config', script,
@@ -90,8 +90,9 @@ include 'components/filecopy/config';
 '/software/components/gridmapdir/dependencies' = {
 
     if(GRIDMAPDIR_FILES_PERMS){
-         SELF['pre'] = append(SELF['pre'], 'filecopy');
+        SELF['pre'] = append(SELF['pre'], 'filecopy');
     };
+
     SELF;
 };
 
@@ -111,11 +112,14 @@ include GRIDMAPDIR_SHARED_NFS_INCLUDE;
 
 # Subscribe to NFS client configuration as a pre dependency
 variable NFS_CLIENT_PREDEP_SUBSCRIBERS = {
-    if ( is_defined(GRIDMAPDIR_SHARED_NFS_INCLUDE) &&
-       (GRIDMAPDIR_SHARED_SERVER != FULL_HOSTNAME) ) {
+    if (
+        is_defined(GRIDMAPDIR_SHARED_NFS_INCLUDE) &&
+        (GRIDMAPDIR_SHARED_SERVER != FULL_HOSTNAME)
+    ) {
 
-       SELF[length(SELF)] = 'gridmapdir';
+        SELF[length(SELF)] = 'gridmapdir';
     };
+
     SELF;
 };
 

--- a/features/mkgridmap/base.pan
+++ b/features/mkgridmap/base.pan
@@ -1,28 +1,29 @@
-
 unique template features/mkgridmap/base;
 
 # Add RPMs
-include { 'features/mkgridmap/rpms' };
+include 'features/mkgridmap/rpms';
 
 # Hack to workaround an undefined conf path listen by ncm-mkgridmap
 '/system/edg/config/EDG_LOCATION' = 'Not.used.anymore';
 
-include { 'components/mkgridmap/config' };
+include 'components/mkgridmap/config';
 
 variable MKGRIDMAP_BIN ?= GLITE_LOCATION_SBIN;
 variable MKGRIDMAP_CONF_DIR ?= GLITE_LOCATION_ETC;
-variable MKGRIDMAP_LCMAPS_DIR ?= GLITE_LOCATION_ETC+'/lcmaps/';
-variable MKGRIDMAP_DEF_CONF ?= MKGRIDMAP_CONF_DIR+"/edg-mkgridmap.conf";
+variable MKGRIDMAP_LCMAPS_DIR ?= GLITE_LOCATION_ETC + '/lcmaps/';
+variable MKGRIDMAP_DEF_CONF ?= MKGRIDMAP_CONF_DIR + '/edg-mkgridmap.conf';
 
 # Update gridmap file every 30mn on a UI as it relies only on gridmap file
 # Run every 3 hours on services relying mainly on VOMS
-variable MKGRIDMAP_REFRESH_INTERVAL = if ( exists(GSISSH_SERVER_ENABLED) &&
-                                           is_defined(GSISSH_SERVER_ENABLED) &&
-                                           GSISSH_SERVER_ENABLED ) {
-                                        return("0-59/30 * * * *");
-                                      } else {
-                                        return("AUTO 0-23/3 * * *");
-                                      };
+variable MKGRIDMAP_REFRESH_INTERVAL = if ( 
+    exists(GSISSH_SERVER_ENABLED) &&
+    is_defined(GSISSH_SERVER_ENABLED) &&
+    GSISSH_SERVER_ENABLED ) {
+
+    return("0-59/30 * * * *");
+} else {
+    return("AUTO 0-23/3 * * *");
+};
 
 
 #----------------------------------------------------------------------------
@@ -32,72 +33,116 @@ variable MKGRIDMAP_REFRESH_INTERVAL = if ( exists(GSISSH_SERVER_ENABLED) &&
 # If GRIDMAPDIR_SHARED_PATH is defined, it must be the path to the shared
 # gridmapdir. If the sharing protocol is NFS, configure NFS.
 #----------------------------------------------------------------------------
-include { 'components/gridmapdir/config' };
+include 'components/gridmapdir/config';
 
 "/software/components/gridmapdir/" = {
-  SELF['gridmapdir'] = SITE_DEF_GRIDMAPDIR;
 
-  # Shared gridmapdir, if enabled, is configured only on listed clients,
-  # if a list is defined. If gridmapdir is NFS-shared, do not configure
-  # the sharedGridmapdir property on the machine serving it.
-  if ( is_defined(GRIDMAPDIR_SHARED_PATH) ) {
-    if ( ((GRIDMAPDIR_SHARED_SERVER != FULL_HOSTNAME) || !match(to_lowercase(GRIDMAPDIR_SHARED_PROTOCOL), '^nfs')) &&
-         (!is_defined(GRIDMAPDIR_SHARED_CLIENTS) || (index(FULL_HOSTNAME,GRIDMAPDIR_SHARED_CLIENTS) >= 0) ) ) {
-      SELF['sharedGridmapdir'] = GRIDMAPDIR_SHARED_PATH;
+    SELF['gridmapdir'] = SITE_DEF_GRIDMAPDIR;
+    
+    # Shared gridmapdir, if enabled, is configured only on listed clients,
+    # if a list is defined. If gridmapdir is NFS-shared, do not configure
+    # the sharedGridmapdir property on the machine serving it.
+    if ( is_defined(GRIDMAPDIR_SHARED_PATH) ) {
+        if ( 
+            ((GRIDMAPDIR_SHARED_SERVER != FULL_HOSTNAME) || !match(to_lowercase(GRIDMAPDIR_SHARED_PROTOCOL), '^nfs')) &&
+            (!is_defined(GRIDMAPDIR_SHARED_CLIENTS) || (index(FULL_HOSTNAME,GRIDMAPDIR_SHARED_CLIENTS) >= 0) )
+        ) {
+            SELF['sharedGridmapdir'] = GRIDMAPDIR_SHARED_PATH;
+        };
     };
-  };
 
-  if ( is_defined(GLITE_GROUP) ) {
-    SELF['group'] = GLITE_GROUP;
-    SELF['perms'] = '0775';
-  };
+    if ( is_defined(GLITE_GROUP) ) {
+        SELF['group'] = GLITE_GROUP;
+        SELF['perms'] = '0775';
+    };
 
-  SELF;
+    SELF;
 };
 
-variable GRIDMAPDIR_SHARED_NFS_INCLUDE = {
-  if ( is_defined(GRIDMAPDIR_SHARED_PATH) && match(to_lowercase(GRIDMAPDIR_SHARED_PROTOCOL), '^nfs') ) {
+# Workaround: the gridmapdir component does not change the ownership and perissions of the files
+# in the gridmapdir. If the link creation is performed by another user this causes a Permission
+# Denied error. Working around with a script, to be launched after mapdir creation.
+
+variable GRIDMAPDIR_FILES_PERMS ?= false;
+
+include 'components/filecopy/config';
+
+'/software/components/filecopy/services' = {
+    if(GRIDMAPDIR_FILES_PERMS){
+       
+        script_name = '/etc/grid-security/mapdir-perms.sh';
+        
+        script = "#! /bin/bash\n" + 
+                 "chown root:" + GLITE_GROUP + " " + SITE_DEF_GRIDMAPDIR + "/*\n" +
+                 "chmod 660 " + SITE_DEF_GRIDMAPDIR + "/*\n";  
+
+        SELF[escape(script_name)] = dict(
+            'config', script,
+            'perms', '0700',
+            'restart', script_name,
+            'forceRestart', true,
+        );
+    };
+
+    SELF;
+};
+
+'/software/components/gridmapdir/dependencies' = {
+
+    if(GRIDMAPDIR_FILES_PERMS){
+         SELF['pre'] = append(SELF['pre'], 'filecopy');
+    };
+    SELF;
+};
+
+
+variable GRIDMAPDIR_SHARED_NFS_INCLUDE = if (
+    is_defined(GRIDMAPDIR_SHARED_PATH) &&
+    match(to_lowercase(GRIDMAPDIR_SHARED_PROTOCOL), '^nfs')
+) {
+
     'features/nfs/gridmapdir';
-  } else {
+} else {
+
     undef;
-  };
 };
-include { GRIDMAPDIR_SHARED_NFS_INCLUDE };
+
+include GRIDMAPDIR_SHARED_NFS_INCLUDE;
 
 # Subscribe to NFS client configuration as a pre dependency
 variable NFS_CLIENT_PREDEP_SUBSCRIBERS = {
-  if ( is_defined(GRIDMAPDIR_SHARED_NFS_INCLUDE) &&
+    if ( is_defined(GRIDMAPDIR_SHARED_NFS_INCLUDE) &&
        (GRIDMAPDIR_SHARED_SERVER != FULL_HOSTNAME) ) {
-    SELF[length(SELF)] = 'gridmapdir';
-  };
-  SELF;
+
+       SELF[length(SELF)] = 'gridmapdir';
+    };
+    SELF;
 };
 
 #----------------------------------------------------------------------------
 # cron
 #----------------------------------------------------------------------------
-include { 'components/cron/config' };
+include 'components/cron/config';
 
-"/software/components/cron/entries" =
-  push(nlist(
-    "name","lcg-expiregridmapdir",
-    "user","root",
+"/software/components/cron/entries" = push(dict(
+    "name", "lcg-expiregridmapdir",
+    "user", "root",
     "frequency", "0 5 * * *",
-    "command", MKGRIDMAP_BIN+"/lcg-expiregridmapdir.pl -v 1"));
+    "command", MKGRIDMAP_BIN + "/lcg-expiregridmapdir.pl -v 1"
+));
 
 
 # ----------------------------------------------------------------------------
 # altlogrotate
 # ----------------------------------------------------------------------------
-include { 'components/altlogrotate/config' };
+include 'components/altlogrotate/config';
 
-"/software/components/altlogrotate/entries/lcg-expiregridmapdir" =
-  nlist("pattern", "/var/log/lcg-expiregridmapdir.ncm-cron.log",
-        "compress", true,
-        "missingok", true,
-        "frequency", "weekly",
-        "create", true,
-        "ifempty", true,
-        "rotate", 2);
-
-
+"/software/components/altlogrotate/entries/lcg-expiregridmapdir" = dict(
+    "pattern", "/var/log/lcg-expiregridmapdir.ncm-cron.log",
+    "compress", true,
+    "missingok", true,
+    "frequency", "weekly",
+    "create", true,
+    "ifempty", true,
+    "rotate", 2
+);

--- a/machine-types/grid/ce.pan
+++ b/machine-types/grid/ce.pan
@@ -13,7 +13,7 @@ variable EMI_LOCATION ?= "";
 variable EMI_LOCATION_LOG ?= "/var/log/emi";
 variable EMI_LOCATION_VAR ?= "/var/emi";
 variable EMI_LOCATION_TMP ?= "/var/spool/emi";
-
+variable CE_TYPE ?= 'cream';
 
 
 # If defined, use CE_TORQUE_CONFIG_SITE for backward compatibility
@@ -36,7 +36,7 @@ variable CONFIGURE_VOS = true;
 variable CREATE_HOME ?= undef;
 variable NODE_VO_GRIDMAPDIR_CONFIG ?= true;
 variable NODE_VO_INFO_DIR = true;
-
+variable CE_FLAVOR ?= 'cream';
 
 #
 # Configure NFS-served file systems in WN_SHARED_AREAS, if any
@@ -53,7 +53,15 @@ include { 'machine-types/grid/base' };
 # CREAM CE configuration
 # If CE uses Torque, do Torque configuration too
 #
-include { 'personality/cream_ce/service' };
+include if(CE_FLAVOR == 'cream'){
+    'personality/cream_ce/service';
+}else if(CE_FLAVOR == 'condorce'){
+
+    'features/htcondor/condorce';
+
+}else{
+    error("Unrecognized CE_TYPE " + CE_TYPE);
+};
 
 
 # Add local customization to standard configuration, if any

--- a/machine-types/grid/ce.pan
+++ b/machine-types/grid/ce.pan
@@ -18,10 +18,10 @@ variable CE_TYPE ?= 'cream';
 
 # If defined, use CE_TORQUE_CONFIG_SITE for backward compatibility
 variable CE_CONFIG_SITE ?= if ( exists(CE_TORQUE_CONFIG_SITE) && is_defined(CE_TORQUE_CONFIG_SITE) ) {
-                             return(CE_TORQUE_CONFIG_SITE);
-                           } else {
-                             return(null);
-                           };
+    return(CE_TORQUE_CONFIG_SITE);
+} else {
+    return(null);
+};
 
 
 # Do actual NFS configuration after gLite configuration instead of during the OS
@@ -46,7 +46,7 @@ variable NFS_CLIENT_ENABLED ?= undef;
 
 # Include base configuration of a gLite node
 #
-include { 'machine-types/grid/base' };
+include 'machine-types/grid/base';
 
 
 #
@@ -55,6 +55,7 @@ include { 'machine-types/grid/base' };
 #
 include if(CE_FLAVOR == 'cream'){
     'personality/cream_ce/service';
+
 }else if(CE_FLAVOR == 'condorce'){
 
     'features/htcondor/condorce';
@@ -65,32 +66,33 @@ include if(CE_FLAVOR == 'cream'){
 
 
 # Add local customization to standard configuration, if any
-include { return(CE_CONFIG_SITE) };
+include return(CE_CONFIG_SITE);
 
 
 #
 # Configure NFS if necessary
 #
-include { if ( NFS_SERVER_ENABLED ) 'features/nfs/server/config' };
-include { if ( NFS_CLIENT_ENABLED ) 'features/nfs/client/config' };
+include if ( NFS_SERVER_ENABLED ) 'features/nfs/server/config';
+include if ( NFS_CLIENT_ENABLED ) 'features/nfs/client/config';
 
 
 #
 #lemon monitoring specific for CEs
 #
 variable LEMON_AGENT_NODE_SPECIFIC = if ( LEMON_CONFIGURE_AGENT ) {
-                         return("monitoring/lemon/client/ce/config");
-                       } else {
-                         return(null);
-                       };
-include { LEMON_AGENT_NODE_SPECIFIC };
+    return("monitoring/lemon/client/ce/config");
+} else {
+    return(null);
+};
+
+include LEMON_AGENT_NODE_SPECIFIC;
 
 #
 # middleware updates
 #
-include { if_exists('update/config') };
+include if_exists('update/config');
 
 # Do any final configuration needed for some reasons (e.g. : run gLite 3.0 on SL4)
 # Should be done at the very end of machine configuration
 #
-include { if_exists(GLITE_OS_POSTCONFIG) };
+include if_exists(GLITE_OS_POSTCONFIG);


### PR DESCRIPTION
HTCondorCE templates. Currently running in pre-production (a.k.a. running SAM tests) at GRIF. We will soon create a production instance using these templates running LHC jobs. This PR can wait until we are stably running in production to be merged. Besides specific htcondorce templates, the PR also syncs the templates in production at GRIF for `htcondor`, `gip` and `accounting/apel` features.