### PR TITLE
users: Fix collisions with system managed groups

### DIFF
--- a/users/edginfo.pan
+++ b/users/edginfo.pan
@@ -1,21 +1,16 @@
-
 unique template users/edginfo;
 
-# -----------------------------------------------------------------------------
-# accounts
-# -----------------------------------------------------------------------------
-include { 'components/accounts/config' };
+include 'components/accounts/config';
 
-include { 'users/infosys' };
+include 'users/infosys';
 
-"/software/components/accounts/groups/edginfo" =
-  nlist("gid", 999);
+"/software/components/accounts/groups/edginfo" = dict("gid", 999);
 
-"/software/components/accounts/users/edginfo" = nlist(
-  "uid", 999,
-  "groups", list("edginfo","infosys"),
-  "comment","EDG Info",
-  "shell", "/bin/bash",
-  "homeDir", "/home/edginfo"
+"/software/components/accounts/users/edginfo" = dict(
+    "uid", 999,
+    "groups", list("edginfo", "infosys"),
+    "comment", "EDG Info",
+    "shell", "/bin/bash",
+    "homeDir", "/home/edginfo",
 );
 

--- a/users/edginfo.pan
+++ b/users/edginfo.pan
@@ -4,7 +4,7 @@ include 'components/accounts/config';
 
 include 'users/infosys';
 
-"/software/components/accounts/groups/edginfo" = dict("gid", 999);
+"/software/components/accounts/groups/edginfo" = dict("gid", 1999);
 
 "/software/components/accounts/users/edginfo" = dict(
     "uid", 999,

--- a/users/infosys.pan
+++ b/users/infosys.pan
@@ -1,12 +1,5 @@
-
 unique template users/infosys;
 
-# -----------------------------------------------------------------------------
-# infosys is a group shared by all accounts collecting information
-# -----------------------------------------------------------------------------
-include { 'components/accounts/config' };
+include 'components/accounts/config';
 
-"/software/components/accounts/groups/infosys" =
-  nlist("gid", 997);
-
-
+"/software/components/accounts/groups/infosys" = dict("gid", 997);

--- a/users/infosys.pan
+++ b/users/infosys.pan
@@ -2,4 +2,4 @@ unique template users/infosys;
 
 include 'components/accounts/config';
 
-"/software/components/accounts/groups/infosys" = dict("gid", 997);
+"/software/components/accounts/groups/infosys" = dict("gid", 1997);


### PR DESCRIPTION
From EL7 onwards, non-system IDs should be above 1000, the existing values conflict with system managed groups.

Fixes #226.

I believe this is backwards incompatible as ncm-accounts will alter existing groups, which may have interesting side-effects.