### PR TITLE
umd-3: Fix max_threads reference

### DIFF
--- a/defaults/grid/config.pan
+++ b/defaults/grid/config.pan
@@ -1199,7 +1199,7 @@ variable WN_CPU_CONFIG = {
                 slot_num = core_num;
 
                 # Take SMT into account when calculating slots
-                if (is_defined(wn_hw['cpu'][0]['max_threads']) && wn_hw['cpu'][0]['max_threads']) {
+                if (is_defined(wn_hw['cpu'][0]['max_threads'])) {
                     # TODO: Only apply this if SMT is enabled system-wide
                     slot_num = cpu_num * wn_hw['cpu'][0]['max_threads'];
                 } else if (is_defined(wn_hw['cpu'][0]['hyperthreading']) && wn_hw['cpu'][0]['hyperthreading']) {


### PR DESCRIPTION
If max_threads is defined it cannot be used in a boolean context. Being defined is enough as we've introduced validation in the schema to ensure the value is not smaller than the core count.

This is only really needed to fix the tests on other template library repos.