### PR TITLE
features/mysqld: fix syntax error

### DIFF
--- a/features/mysql/server.pan
+++ b/features/mysql/server.pan
@@ -9,7 +9,7 @@ include 'components/etcservices/config';
 # Enable and start MySQL service
 "/software/components/chkconfig/service" ?= dict();
 "/software/components/chkconfig/service" = merge(SELF, dict(
-    mysqld, dict(
+    'mysqld', dict(
         'on', '',
         'startstop', true,
     ),


### PR DESCRIPTION
Fix required to allow the examples to compile successfully (https://github.com/quattor/template-library-grid/pull/246)